### PR TITLE
Fix headless-Chrome thumbnail scratch-dir leak

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "test:artifacts": "tsx test/artifacts.ts",
     "test:auth": "tsx test/auth.ts",
     "test:startup-access": "tsx test/startupAccess.ts",
+    "test:thumbs": "tsx test/thumbs.ts",
     "test:e2e": "tsx test/e2e.ts"
   },
   "bin": {

--- a/server/thumbs.ts
+++ b/server/thumbs.ts
@@ -16,6 +16,26 @@ let serverPort = 0;
 
 export function setThumbServerPort(port: number) {
   serverPort = port;
+  sweepStaleChromeDirs();
+}
+
+// Headless-Chrome scratch dirs (`.chrome-*` user-data-dirs) can leak when a
+// capture is killed before cleanup finishes — a SIGKILL on timeout, or a hard
+// process/host crash. At boot no capture is in flight, so every leftover
+// `.chrome-*` under the data dir is stale and safe to delete. This makes the
+// leak self-healing across restarts rather than letting dirs accumulate.
+function sweepStaleChromeDirs() {
+  let entries: string[];
+  try { entries = fs.readdirSync(getDataDir()); } catch { return; }
+  let removed = 0;
+  for (const name of entries) {
+    if (!name.startsWith(".chrome-")) continue;
+    try {
+      fs.rmSync(path.join(getDataDir(), name), { recursive: true, force: true, maxRetries: 3 });
+      removed++;
+    } catch {}
+  }
+  if (removed) console.log(`[thumbs] swept ${removed} stale chrome scratch dir(s)`);
 }
 
 function thumbsDir(): string {
@@ -149,8 +169,22 @@ async function capture(job: Job): Promise<void> {
   let child: ChildProcess | null = null;
   let settled = false;
   const cleanup = () => {
-    try { if (child && !child.killed) child.kill("SIGKILL"); } catch {}
-    fs.rm(tmpDir, { recursive: true, force: true }, () => {});
+    // Remove the scratch dir only AFTER Chrome has exited — a just-SIGKILLed
+    // process still holds open handles under user-data-dir, and rm-ing into that
+    // race is what leaks dirs. Retry as a backstop, plus a timed fallback in
+    // case the exit event never arrives.
+    const removeDir = () => fs.rm(tmpDir, { recursive: true, force: true, maxRetries: 5, retryDelay: 200 }, () => {});
+    try {
+      if (child && !child.killed) {
+        child.once("exit", removeDir);
+        setTimeout(removeDir, 3000).unref();
+        child.kill("SIGKILL");
+      } else {
+        removeDir();
+      }
+    } catch {
+      removeDir();
+    }
   };
 
   return new Promise<void>((resolve, reject) => {

--- a/test/thumbs.ts
+++ b/test/thumbs.ts
@@ -1,0 +1,58 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+// Isolate the data dir BEFORE importing thumbs (getDataDir caches on first call).
+const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), "surface-thumbs-test-"));
+process.env.SURFACE_DATA_DIR = tmpRoot;
+
+const { setThumbServerPort, getThumbPath } = await import("../server/thumbs.js");
+
+function test(name: string, fn: () => void) {
+  try {
+    fn();
+    console.log(`  PASS  ${name}`);
+  } catch (err) {
+    console.error(`  FAIL  ${name}`);
+    throw err;
+  }
+}
+
+console.log("\n=== Thumbnail Tests ===\n");
+
+// The boot sweep is what stops headless-Chrome scratch dirs from accumulating
+// across restarts: every leftover `.chrome-*` under the data dir is stale at
+// boot and must be removed — but real data must be left untouched.
+test("boot sweep clears stale .chrome-* dirs and keeps real files", () => {
+  fs.mkdirSync(path.join(tmpRoot, ".chrome-aaa"), { recursive: true });
+  fs.writeFileSync(path.join(tmpRoot, ".chrome-aaa", "SingletonLock"), "x"); // simulate Chrome's locked file
+  fs.mkdirSync(path.join(tmpRoot, ".chrome-bbb", "Default"), { recursive: true });
+  fs.mkdirSync(path.join(tmpRoot, "thumbs"), { recursive: true });
+  fs.writeFileSync(path.join(tmpRoot, "thumbs", "keep.png"), "img");
+  fs.writeFileSync(path.join(tmpRoot, "db.sqlite"), "data");
+
+  setThumbServerPort(0); // triggers sweepStaleChromeDirs()
+
+  assert.ok(!fs.existsSync(path.join(tmpRoot, ".chrome-aaa")), "stale .chrome-aaa removed");
+  assert.ok(!fs.existsSync(path.join(tmpRoot, ".chrome-bbb")), "stale .chrome-bbb removed");
+  assert.ok(fs.existsSync(path.join(tmpRoot, "thumbs", "keep.png")), "thumbnails preserved");
+  assert.ok(fs.existsSync(path.join(tmpRoot, "db.sqlite")), "database preserved");
+});
+
+test("boot sweep is a no-op when there are no scratch dirs", () => {
+  // Second call: nothing left to sweep, must not throw or touch real files.
+  setThumbServerPort(0);
+  assert.ok(fs.existsSync(path.join(tmpRoot, "db.sqlite")), "database still preserved");
+});
+
+// getThumbPath is the defensive last line against an unsafe id reaching the FS.
+test("getThumbPath rejects traversal / absolute ids, accepts safe ids", () => {
+  assert.throws(() => getThumbPath("../evil"), /Invalid artifact id/);
+  assert.throws(() => getThumbPath("/abs"), /Invalid artifact id/);
+  assert.throws(() => getThumbPath("a/b"), /Invalid artifact id/);
+  assert.equal(getThumbPath("good-id_1"), path.join(tmpRoot, "thumbs", "good-id_1.png"));
+});
+
+fs.rmSync(tmpRoot, { recursive: true, force: true });
+console.log("\nThumbnail tests passed\n");


### PR DESCRIPTION
The thumbnailer's `.chrome-*` user-data-dirs were accumulating in the data dir (~50 leaked on the live deploy, back to May).

**Root cause:** `cleanup()` SIGKILLed Chrome and *immediately* `fs.rm`'d the scratch dir. A just-killed Chrome still holds open handles under `--user-data-dir`, so the async rm raced and partially failed — and the no-op callback swallowed the error. Crashes/timeouts compounded it across restarts.

**Fix:**
- Per-capture cleanup now removes the dir **after** Chrome's `exit` event, with `fs.rm` `maxRetries`, plus a timed fallback if `exit` never fires.
- `setThumbServerPort` (boot) sweeps any leftover `.chrome-*` dirs — at boot no capture is in flight, so leftovers are stale and safe to delete. Makes the leak self-healing across restarts.

`tsc --noEmit` clean. Verified live: boot sweep cleared the backlog (see service log `[thumbs] swept N stale chrome scratch dir(s)`).