### PR TITLE
Surface-native two-way design: stage/commit batching + SKILL.md guidance

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -11,6 +11,14 @@ The command set is curated: the hottest paths get top-level verbs (`ask`, `video
 
 `surface <command> --help` is authoritative for flags. The notes below tell you *when* to use each command.
 
+## Make it Surface-native
+
+Surface isn't a chat transcript or a file viewer — it's a live display the user *acts on*. Default to surfaces that are **two-way and current**: the user can answer, click, or watch a value change, and you react. That loop — `surface ask`, `Surface.action()`, live `surface set` + state bindings, the delivery ladder below — is the native idiom, not an advanced feature. A wall of text you could have printed to the terminal is the thing to avoid.
+
+Reach for **dynamic, interactive HTML** — charts, maps, timelines, small tools, anything in the shape of `examples/demos/` — whenever a custom surface lets the user understand or act *faster* than prose would. The medium is the full web platform; use it.
+
+**But don't force it.** Dynamism earns its place when it adds a decision, a live value, or a spatial/visual relationship text can't carry. It's gratuitous when it dresses up a plain answer: a yes/no is `surface ask`, not a bespoke dashboard; a single status is one bound number, not an animation. Native means *fit to the task* in both directions — never less interactive than the task wants, never more.
+
 ## Session start ritual
 
 1. `surface actions` — drain your inbox: clicks that arrived while you were gone. Handle each one, then `surface ack <action-id>` (actions delivered through `surface wait` are acked automatically). Don't ignore them.
@@ -20,15 +28,17 @@ The command set is curated: the hottest paths get top-level verbs (`ask`, `video
 
 ## Creating content — pick by shape, not by habit
 
+Most content has a purpose-built verb — reach for it. But when the user is served by a custom shape (interactive, visual, or two-way), **building ad-hoc HTML is a first-class default, not a last resort.**
+
 | The content is… | Use |
 |---|---|
 | A question you need answered | `surface ask` (see below) — not a hand-written form |
+| **An interactive tool, chart, map, or custom UI** | **`surface create <title> --mime text/html --content -` — full HTML; wire it two-way with `Surface.action()` + state bindings** |
 | A long-running log / narration | `surface create <t> --id <slug> --template stream`, then `surface append <id> [text\|-] [--md]` |
 | A YouTube/web video | `surface video <url> [--start <s>] [--autoplay] [--loop]` |
 | A markdown file in the repo | `surface doc <path> [--toc] [--width narrow\|default\|wide]` |
 | A file in your project you'll keep editing | `surface link <abs-path> [--entry <rel>]` — served live from disk |
 | An instance of any template, built-in or custom | `surface create <t> --template <name> --param k=v …` — check `surface template list` first |
-| Ad-hoc HTML/interactive UI | `surface create <title> --mime text/html --content -` |
 | A one-shot file snapshot (PDF, image) | `surface present <abs-path>` |
 
 `link` and `doc` navigate every display to the new surface by default — pass `--no-open` to create quietly.
@@ -54,7 +64,9 @@ surface patch build '{"stage":"deploy","eta_s":90}'   # deep-merge (or pipe JSON
 surface state build                      # read it back
 ```
 
-In your HTML, bind with `data-surface-bind="tests.passed"` / `data-surface-show="deploy.ready"` — the injected `surface.js` runtime re-renders bound elements live on every display. Emit actions from markup with `Surface.action("name", {...})`.
+In your HTML, bind with `data-surface-bind="tests.passed"` / `data-surface-show="deploy.ready"` — the injected `surface.js` runtime re-renders bound elements live on every display. Emit actions from markup with `Surface.action("name", {...})`. Together these are the native two-way loop: **state flows out** to every screen, **actions flow back** to you — a surface that only renders is half-built.
+
+**Emit at boundaries, not per twitch.** Each `Surface.action()` wakes you. For a multi-step interaction (pick options, toggle, then submit), keep the intermediate clicks *local* and fire once at the commit: `Surface.stage(key, value)` accumulates client-side with no network, and `Surface.commit("name"[, extra])` emits a single action carrying the full staged payload — including options left at their defaults. So you wake once, on the user's actual intent, with the whole picture — never once per click, never on a blind timer. Reserve bare `Surface.action()` for genuinely standalone clicks.
 
 ## Asking the user: `surface ask`
 

--- a/client/surface.js
+++ b/client/surface.js
@@ -164,12 +164,19 @@
   }
 
   function commit(name, extra) {
+    if (!name) return Promise.reject(new Error("commit(name): action name is required"));
     var payload = stagedCopy();
     if (extra && typeof extra === "object") {
       for (var e in extra) payload[e] = extra[e];
     }
-    staged = {};
-    return action(name, payload);
+    // Clear the staged buffer only AFTER the action is accepted. A falsy name, a
+    // server rejection (res.error), or a network failure must not lose the
+    // user's buffered intent — so they can retry the commit.
+    return Promise.resolve(action(name, payload)).then(function (res) {
+      if (res && res.error) throw new Error("commit failed: " + res.error);
+      staged = {};
+      return res;
+    });
   }
 
   window.Surface = {

--- a/client/surface.js
+++ b/client/surface.js
@@ -144,6 +144,34 @@
     }).then(function (r) { return r.json(); });
   }
 
+  // Stage / commit — batch at the surface, not at the agent. Intermediate
+  // clicks (picking options, toggling) stay LOCAL via stage(); a single
+  // commit() emits ONE action carrying the full picture, so the agent wakes
+  // once on the user's actual intent — not once per twitch, and not on a
+  // blind timer. Reserve bare action() for genuinely standalone clicks.
+  var staged = {};
+
+  function stage(key, value) {
+    if (value === undefined) delete staged[key];
+    else staged[key] = value;
+    return stagedCopy();
+  }
+
+  function stagedCopy() {
+    var c = {};
+    for (var k in staged) c[k] = staged[k];
+    return c;
+  }
+
+  function commit(name, extra) {
+    var payload = stagedCopy();
+    if (extra && typeof extra === "object") {
+      for (var e in extra) payload[e] = extra[e];
+    }
+    staged = {};
+    return action(name, payload);
+  }
+
   window.Surface = {
     id: artifactId,
     get state() { return state; },
@@ -162,6 +190,10 @@
       };
     },
     action: action,
+    stage: stage,
+    commit: commit,
+    staged: stagedCopy,
+    clearStaged: function () { staged = {}; },
   };
 
   function boot() {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "test:startup-access": "tsx test/startupAccess.ts",
     "test:thumbs": "tsx test/thumbs.ts",
     "test:runtime": "tsx test/runtime.ts",
+    "test:bindings": "tsx test/bindings.ts",
     "test:e2e": "tsx test/e2e.ts"
   },
   "bin": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "test:auth": "tsx test/auth.ts",
     "test:startup-access": "tsx test/startupAccess.ts",
     "test:thumbs": "tsx test/thumbs.ts",
+    "test:runtime": "tsx test/runtime.ts",
     "test:e2e": "tsx test/e2e.ts"
   },
   "bin": {

--- a/test/bindings.ts
+++ b/test/bindings.ts
@@ -1,0 +1,208 @@
+import assert from "node:assert/strict";
+import { spawn, ChildProcess } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+// End-to-end verification of the wake-binding revival path (the "tap a button
+// at 11pm and the offline agent's session is respawned" flow). We boot a real
+// isolated server, register a command binding, fire a click with NO live
+// waiter, and prove the bound command actually runs — with the full pending
+// action batch on stdin, the right cwd, env, and inbox ack — plus the two
+// guardrails: a live waiter suppresses it, and a non-matching pattern doesn't
+// fire. The bound command stands in for `claude -p --resume <session>`; we
+// assert the contract that revival relies on, without burning a real session.
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.join(__dirname, "..");
+const PORT = 34000 + (process.pid % 1000);
+const BASE = `http://127.0.0.1:${PORT}`;
+
+const dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "surface-bind-data-"));
+const projectRoot = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "surface-bind-proj-")));
+const captureOut = path.join(dataDir, "capture-out.json");
+
+// The stand-in for the revived harness: read the action batch on stdin and
+// record everything the binding contract promises (stdin, cwd, env).
+const capturePath = path.join(dataDir, "capture.js");
+fs.writeFileSync(
+  capturePath,
+  `const fs = require("fs");
+let stdin = "";
+try { stdin = fs.readFileSync(0, "utf8"); } catch (e) {}
+fs.writeFileSync(process.argv[2], JSON.stringify({
+  stdin: stdin,
+  cwd: process.cwd(),
+  bindingId: process.env.SURFACE_BINDING_ID || null,
+  surfaceId: process.env.SURFACE_SURFACE_ID || null,
+}));
+`,
+);
+
+let server: ChildProcess | null = null;
+let serverErr = "";
+
+async function call(method: string, p: string, body?: unknown): Promise<{ status: number; json: any }> {
+  const res = await fetch(BASE + p, {
+    method,
+    headers: body !== undefined ? { "Content-Type": "application/json" } : {},
+    body: body !== undefined ? JSON.stringify(body) : undefined,
+  });
+  let json: any = null;
+  try { json = await res.json(); } catch {}
+  return { status: res.status, json };
+}
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+async function waitForServer(timeoutMs: number) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    try {
+      const res = await fetch(BASE + "/artifacts");
+      if (res.ok) return;
+    } catch {}
+    await sleep(150);
+  }
+  throw new Error(`server did not come up on ${BASE}\n--- server stderr ---\n${serverErr}`);
+}
+
+async function listening(id: string): Promise<boolean> {
+  const { json } = await call("GET", "/artifacts");
+  const card = Array.isArray(json) ? json.find((c: any) => c.id === id) : null;
+  return !!(card && card.listening);
+}
+
+async function pendingCount(id: string): Promise<number> {
+  const { json } = await call("GET", `/artifacts/${id}/actions`);
+  return Array.isArray(json) ? json.length : -1;
+}
+
+async function waitFor(pred: () => Promise<boolean>, timeoutMs: number, label: string) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (await pred()) return;
+    await sleep(100);
+  }
+  throw new Error(`timed out waiting for: ${label}`);
+}
+
+function test(name: string, fn: () => Promise<void>) {
+  return fn()
+    .then(() => console.log(`  PASS  ${name}`))
+    .catch((err) => { console.error(`  FAIL  ${name}`); throw err; });
+}
+
+async function main() {
+  server = spawn(path.join(repoRoot, "node_modules", ".bin", "tsx"), ["server/index.ts"], {
+    cwd: repoRoot,
+    env: {
+      ...process.env,
+      SURFACE_DATA_DIR: dataDir,
+      PORT: String(PORT),
+      SURFACE_BIND: "127.0.0.1",
+      SURFACE_PAIR_ON_START: "0",
+      NODE_ENV: "test",
+    },
+    stdio: ["ignore", "ignore", "pipe"],
+  });
+  server.stderr!.setEncoding("utf8");
+  server.stderr!.on("data", (c: string) => { serverErr += c; });
+
+  await waitForServer(15000);
+  console.log("\n=== Wake-binding (revival path) Tests ===\n");
+
+  const id = "wake-test-surface";
+
+  await test("setup: create surface + register a wake binding", async () => {
+    const created = await call("POST", "/artifacts", {
+      id,
+      title: "Wake test",
+      mime: "text/html",
+      content: "<h1>wake</h1>",
+      project_root: projectRoot,
+    });
+    assert.equal(created.status, 201, "artifact created");
+
+    const bind = await call("POST", `/artifacts/${id}/bindings`, {
+      action_pattern: "wake",
+      run: `node "${capturePath}" "${captureOut}"`,
+    });
+    assert.equal(bind.status, 201, "binding registered");
+    assert.equal(bind.json.kind, "command");
+
+    const list = await call("GET", `/artifacts/${id}/bindings`);
+    assert.equal(list.json.length, 1, "one binding listed");
+  });
+
+  await test("click with NO waiter spawns the command with the batch on stdin", async () => {
+    if (fs.existsSync(captureOut)) fs.rmSync(captureOut);
+    const act = await call("POST", `/artifacts/${id}/actions`, { action: "wake", data: { foo: 1 } });
+    assert.equal(act.status, 201, "action accepted");
+
+    await waitFor(() => Promise.resolve(fs.existsSync(captureOut)), 10000, "bound command to run");
+    const rec = JSON.parse(fs.readFileSync(captureOut, "utf8"));
+
+    const batch = JSON.parse(rec.stdin);
+    assert.equal(batch.type, "surface_action_batch", "stdin is the action batch");
+    assert.equal(batch.surface_id, id);
+    assert.ok(Array.isArray(batch.actions) && batch.actions.length >= 1, "batch carries actions");
+    const wake = batch.actions.find((a: any) => a.action === "wake");
+    assert.ok(wake, "the wake action is in the batch");
+    assert.deepEqual(wake.data, { foo: 1 }, "action data delivered intact");
+  });
+
+  await test("command runs with cwd = project root and binding env set", async () => {
+    const rec = JSON.parse(fs.readFileSync(captureOut, "utf8"));
+    assert.equal(fs.realpathSync(rec.cwd), projectRoot, "cwd is the project root");
+    assert.ok(rec.bindingId, "SURFACE_BINDING_ID present");
+    assert.equal(rec.surfaceId, id, "SURFACE_SURFACE_ID is the surface");
+  });
+
+  await test("successful run acks the batch and records status ok", async () => {
+    await waitFor(async () => (await pendingCount(id)) === 0, 5000, "inbox drained after run");
+    const list = await call("GET", `/artifacts/${id}/bindings`);
+    assert.equal(list.json[0].last_status, "ok", "binding status is ok");
+  });
+
+  await test("a non-matching action does NOT fire the binding (stays in inbox)", async () => {
+    fs.rmSync(captureOut, { force: true });
+    const act = await call("POST", `/artifacts/${id}/actions`, { action: "ignored", data: {} });
+    assert.equal(act.status, 201);
+    await sleep(1200);
+    assert.ok(!fs.existsSync(captureOut), "binding did not run for non-matching action");
+    assert.equal(await pendingCount(id), 1, "non-matching action waits in the inbox");
+  });
+
+  await test("a live waiter SUPPRESSES the binding (layer-1 wins)", async () => {
+    const ac = new AbortController();
+    // Hold an SSE waiter open; the connection itself registers the waiter.
+    const streamPromise = fetch(`${BASE}/stream?wait_for=${id}`, { signal: ac.signal }).catch(() => {});
+    try {
+      await waitFor(() => listening(id), 5000, "waiter to register");
+      fs.rmSync(captureOut, { force: true });
+      const act = await call("POST", `/artifacts/${id}/actions`, { action: "wake", data: { foo: 2 } });
+      assert.equal(act.status, 201);
+      await sleep(1200);
+      assert.ok(!fs.existsSync(captureOut), "binding suppressed while a waiter is connected");
+      assert.equal(await pendingCount(id), 2, "both unhandled actions remain pending");
+    } finally {
+      ac.abort();
+      await streamPromise;
+    }
+    await waitFor(async () => !(await listening(id)), 5000, "waiter to disconnect");
+  });
+
+  console.log("\nWake-binding tests passed\n");
+}
+
+main()
+  .then(() => { cleanup(); process.exit(0); })
+  .catch((err) => { console.error(err); cleanup(); process.exit(1); });
+
+function cleanup() {
+  try { server?.kill("SIGKILL"); } catch {}
+  try { fs.rmSync(dataDir, { recursive: true, force: true }); } catch {}
+  try { fs.rmSync(projectRoot, { recursive: true, force: true }); } catch {}
+}

--- a/test/runtime.ts
+++ b/test/runtime.ts
@@ -1,0 +1,138 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import vm from "node:vm";
+
+// surface.js is a browser IIFE (reads document.currentScript, window, fetch,
+// EventSource). We load it into a hand-rolled DOM shim so we can drive
+// Surface.stage()/commit() and assert exactly what hits the network — no jsdom,
+// no build step, matching the repo's zero-dep test convention.
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const runtimeSrc = fs.readFileSync(path.join(__dirname, "..", "client", "surface.js"), "utf8");
+
+interface FetchCall { url: string; method: string; body: any }
+
+function loadRuntime() {
+  const fetchCalls: FetchCall[] = [];
+
+  const fetchMock = (url: string, opts?: any) => {
+    fetchCalls.push({
+      url,
+      method: (opts && opts.method) || "GET",
+      body: opts && opts.body ? JSON.parse(opts.body) : undefined,
+    });
+    // /state hydrate and /actions POST both read .json(); .ok for hydrate.
+    return Promise.resolve({ ok: true, json: () => Promise.resolve({ state: {}, state_version: 0 }) });
+  };
+
+  class EventSourceStub {
+    onerror: any = null;
+    addEventListener() {}
+    constructor(_url: string) {}
+  }
+
+  const documentStub: any = {
+    readyState: "complete", // boot() runs synchronously on load
+    currentScript: { src: "http://localhost/surface.js?id=test-id" },
+    addEventListener() {},
+    querySelectorAll() { return []; },
+  };
+
+  const sandbox: any = {
+    console,
+    URL,
+    fetch: fetchMock,
+    EventSource: EventSourceStub,
+    location: { origin: "http://localhost" },
+    document: documentStub,
+    setTimeout,
+    clearTimeout,
+  };
+  // window IS the global, and window.parent === window (standalone-tab path → fetch).
+  sandbox.window = sandbox;
+  sandbox.window.parent = sandbox.window;
+
+  vm.createContext(sandbox);
+  vm.runInContext(runtimeSrc, sandbox);
+
+  return { Surface: sandbox.window.Surface, fetchCalls };
+}
+
+function test(name: string, fn: () => void | Promise<void>) {
+  return Promise.resolve()
+    .then(fn)
+    .then(() => console.log(`  PASS  ${name}`))
+    .catch((err) => { console.error(`  FAIL  ${name}`); throw err; });
+}
+
+const actionsPosts = (calls: FetchCall[]) =>
+  calls.filter((c) => c.url.includes("/actions") && c.method === "POST");
+
+// staged() builds its object inside the vm realm, so its prototype differs from
+// this realm's Object.prototype and strict deepEqual rejects it. Normalize the
+// shape through JSON before structural comparison.
+const plain = (x: unknown) => JSON.parse(JSON.stringify(x));
+
+console.log("\n=== Surface runtime: stage / commit ===\n");
+
+await test("runtime exposes stage / commit / staged / action", () => {
+  const { Surface } = loadRuntime();
+  assert.equal(typeof Surface.stage, "function");
+  assert.equal(typeof Surface.commit, "function");
+  assert.equal(typeof Surface.staged, "function");
+  assert.equal(typeof Surface.action, "function");
+});
+
+await test("stage() accumulates locally and emits ZERO actions", () => {
+  const { Surface, fetchCalls } = loadRuntime();
+  Surface.stage("region", "us-east");
+  Surface.stage("plan", "pro");
+  Surface.stage("region", "eu-west"); // last write wins
+  assert.equal(actionsPosts(fetchCalls).length, 0, "no action POST before commit");
+  assert.deepEqual(plain(Surface.staged()), { region: "eu-west", plan: "pro" });
+});
+
+await test("commit() emits exactly ONE action with the full staged payload", () => {
+  const { Surface, fetchCalls } = loadRuntime();
+  Surface.stage("region", "eu-west");
+  Surface.stage("plan", "pro");
+  Surface.commit("choices");
+  const posts = actionsPosts(fetchCalls);
+  assert.equal(posts.length, 1, "exactly one action POST");
+  assert.equal(posts[0].body.action, "choices");
+  assert.deepEqual(plain(posts[0].body.data), { region: "eu-west", plan: "pro" });
+});
+
+await test("commit(extra) merges extra over staged, then clears staged", () => {
+  const { Surface, fetchCalls } = loadRuntime();
+  Surface.stage("region", "eu-west");
+  Surface.commit("choices", { confirmed: true });
+  const posts = actionsPosts(fetchCalls);
+  assert.deepEqual(plain(posts[0].body.data), { region: "eu-west", confirmed: true });
+  assert.deepEqual(plain(Surface.staged()), {}, "staged cleared after commit");
+});
+
+await test("stage(key, undefined) unsets; clearStaged() empties", () => {
+  const { Surface } = loadRuntime();
+  Surface.stage("a", 1);
+  Surface.stage("b", 2);
+  Surface.stage("a", undefined);
+  assert.deepEqual(plain(Surface.staged()), { b: 2 });
+  Surface.clearStaged();
+  assert.deepEqual(plain(Surface.staged()), {});
+});
+
+await test("a burst of 4 stages + 1 commit = ONE wake (the whole point)", () => {
+  const { Surface, fetchCalls } = loadRuntime();
+  Surface.stage("g1", "agree");
+  Surface.stage("g2", "agree");
+  Surface.stage("g3", "agree");
+  Surface.stage("g4", "agree");
+  assert.equal(actionsPosts(fetchCalls).length, 0, "four selections, zero wakes");
+  Surface.commit("verdict", { kind: "approve" });
+  assert.equal(actionsPosts(fetchCalls).length, 1, "one commit, one wake");
+});
+
+console.log("\nRuntime tests passed\n");

--- a/test/runtime.ts
+++ b/test/runtime.ts
@@ -14,7 +14,7 @@ const runtimeSrc = fs.readFileSync(path.join(__dirname, "..", "client", "surface
 
 interface FetchCall { url: string; method: string; body: any }
 
-function loadRuntime() {
+function loadRuntime(cfg: { failActions?: boolean } = {}) {
   const fetchCalls: FetchCall[] = [];
 
   const fetchMock = (url: string, opts?: any) => {
@@ -23,6 +23,10 @@ function loadRuntime() {
       method: (opts && opts.method) || "GET",
       body: opts && opts.body ? JSON.parse(opts.body) : undefined,
     });
+    // Simulate a server-rejected action POST so we can assert staged retention.
+    if (cfg.failActions && url.includes("/actions") && opts && opts.method === "POST") {
+      return Promise.resolve({ ok: false, json: () => Promise.resolve({ error: "server rejected" }) });
+    }
     // /state hydrate and /actions POST both read .json(); .ok for hydrate.
     return Promise.resolve({ ok: true, json: () => Promise.resolve({ state: {}, state_version: 0 }) });
   };
@@ -94,21 +98,21 @@ await test("stage() accumulates locally and emits ZERO actions", () => {
   assert.deepEqual(plain(Surface.staged()), { region: "eu-west", plan: "pro" });
 });
 
-await test("commit() emits exactly ONE action with the full staged payload", () => {
+await test("commit() emits exactly ONE action with the full staged payload", async () => {
   const { Surface, fetchCalls } = loadRuntime();
   Surface.stage("region", "eu-west");
   Surface.stage("plan", "pro");
-  Surface.commit("choices");
+  await Surface.commit("choices");
   const posts = actionsPosts(fetchCalls);
   assert.equal(posts.length, 1, "exactly one action POST");
   assert.equal(posts[0].body.action, "choices");
   assert.deepEqual(plain(posts[0].body.data), { region: "eu-west", plan: "pro" });
 });
 
-await test("commit(extra) merges extra over staged, then clears staged", () => {
+await test("commit(extra) merges extra over staged, then clears staged", async () => {
   const { Surface, fetchCalls } = loadRuntime();
   Surface.stage("region", "eu-west");
-  Surface.commit("choices", { confirmed: true });
+  await Surface.commit("choices", { confirmed: true });
   const posts = actionsPosts(fetchCalls);
   assert.deepEqual(plain(posts[0].body.data), { region: "eu-west", confirmed: true });
   assert.deepEqual(plain(Surface.staged()), {}, "staged cleared after commit");
@@ -124,15 +128,35 @@ await test("stage(key, undefined) unsets; clearStaged() empties", () => {
   assert.deepEqual(plain(Surface.staged()), {});
 });
 
-await test("a burst of 4 stages + 1 commit = ONE wake (the whole point)", () => {
+await test("a burst of 4 stages + 1 commit = ONE wake (the whole point)", async () => {
   const { Surface, fetchCalls } = loadRuntime();
   Surface.stage("g1", "agree");
   Surface.stage("g2", "agree");
   Surface.stage("g3", "agree");
   Surface.stage("g4", "agree");
   assert.equal(actionsPosts(fetchCalls).length, 0, "four selections, zero wakes");
-  Surface.commit("verdict", { kind: "approve" });
+  await Surface.commit("verdict", { kind: "approve" });
   assert.equal(actionsPosts(fetchCalls).length, 1, "one commit, one wake");
+});
+
+await test("commit() with no name rejects and preserves staged (no POST)", async () => {
+  const { Surface, fetchCalls } = loadRuntime();
+  Surface.stage("a", 1);
+  await assert.rejects(() => Surface.commit(""), /action name is required/);
+  assert.equal(actionsPosts(fetchCalls).length, 0, "a nameless commit never POSTs");
+  assert.deepEqual(plain(Surface.staged()), { a: 1 }, "staged retained after rejected commit");
+});
+
+await test("a FAILED commit preserves staged data (intent is not lost)", async () => {
+  const { Surface } = loadRuntime({ failActions: true });
+  Surface.stage("region", "eu-west");
+  Surface.stage("plan", "pro");
+  await assert.rejects(() => Surface.commit("choices"), /commit failed/);
+  assert.deepEqual(
+    plain(Surface.staged()),
+    { region: "eu-west", plan: "pro" },
+    "staged retained after a server rejection — the user can retry",
+  );
 });
 
 console.log("\nRuntime tests passed\n");


### PR DESCRIPTION
## What

Two related changes that push agents toward Surface-native, two-way surfaces and make those surfaces wake the agent once per *interaction*, not once per click.

### Runtime: `Surface.stage()` / `Surface.commit()` (`client/surface.js`)
Batch user input at the HTML layer instead of narrating every click to the agent:
- `Surface.stage(key, value)` — accumulate a selection client-side, **no network**.
- `Surface.commit(name[, extra])` — emit **one** action carrying the full staged payload, then clear.
- `Surface.staged()` / `Surface.clearStaged()` — inspect / reset.
- `Surface.action()` is unchanged, for genuinely standalone clicks.

Intermediate clicks (picking options, dragging, toggling) stay local; one commit at the decision boundary delivers the whole picture — including options left at their defaults. The agent wakes once, on the user's intent, never on a blind timer.

### SKILL.md: Surface-native disposition (issues #6 + #7)
Reframes the agent guide from a pure command reference into a disposition-setter:
- A new **"Make it Surface-native"** principle: default to two-way + interactive when it helps the user act/understand faster, plain when it doesn't.
- The content table now treats interactive HTML as a first-class default, not a last resort.
- The state/action loop is framed as *the* native idiom, with an **"Emit at boundaries, not per twitch"** note teaching stage/commit.

This is the actionable resolution of #7 ("don't build another skills system — improve SKILL.md").

## Testing
- New `test/runtime.ts` (`npm run test:runtime`) loads the real `surface.js` into a `node:vm` DOM shim and asserts the contract — N stages = 0 POSTs, commit = exactly 1. All 6 pass.
- `tsc --noEmit` clean.
- Verified live by dogfooding: a drag-to-arrange priority matrix with continuous pointer input woke the agent exactly once on commit.

Closes #6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added interaction staging and batching; multiple user actions can now be staged and committed as a single request.

* **Documentation**
  * Enhanced surface creation guidance emphasizing two-way interactive patterns and dynamic HTML.
  * Expanded state management documentation with binding and staging patterns.

* **Tests**
  * Added runtime test suite validating staging and commit behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->