### PR TITLE
Isolate device-authored surfaces on an untrusted content origin

### DIFF
--- a/client/app.js
+++ b/client/app.js
@@ -7,6 +7,9 @@ let displayConfig = {};
 // Display slots are artifacts (metadata.display_role) — ids resolved by the
 // server at GET /display/slots.
 let displaySlots = { renderer: null, home: null, overlay: null };
+// Origin that device-authored surfaces are embedded from (the untrusted content
+// plane). Set at boot from /display/config.content_port; empty = same origin.
+let contentOrigin = "";
 
 async function refreshSlots() {
   try {
@@ -34,6 +37,10 @@ function maybeRefreshSlots(cardOrId) {
 
 window.addEventListener("message", (e) => {
   if (!e.data) return;
+  // Only honor messages from our own (app) origin. Device-authored surfaces
+  // render on the content origin and post their actions directly to that origin
+  // (surface.js), so they must never reach the trusted bridge here.
+  if (e.origin !== location.origin) return;
 
   // Renderer/overlay/widget navigation
   if (e.data.type === "surface_navigate") {
@@ -1449,11 +1456,17 @@ async function renderSurface(id) {
 
   const iframe = document.createElement("iframe");
   iframe.className = "surface-frame";
-  // Same-origin by design (surface.js needs fetch/SSE); the sandbox attr still
-  // blocks top-navigation and modal abuse from surface content.
+  // The sandbox attr blocks top-navigation and modal abuse. allow-same-origin
+  // lets surface.js use fetch/SSE — but for DEVICE-authored content we load it
+  // from the untrusted content origin, so "same-origin" there is the content
+  // plane (never system), not this trusted app origin. System content stays on
+  // the app origin. (docs/auth/trust-model.md)
   iframe.setAttribute("sandbox", "allow-scripts allow-same-origin allow-forms allow-popups allow-popups-to-escape-sandbox allow-downloads allow-presentation");
   iframe.setAttribute("allow", "autoplay; encrypted-media; picture-in-picture; fullscreen; clipboard-write");
-  iframe.src = data.view_url || `/artifacts/${id}/view`;
+  const viewPath = data.view_url || `/artifacts/${id}/view`;
+  const meta = parseMetadata(artifact.metadata);
+  const fromDevicePlane = meta && meta.author_plane === "device";
+  iframe.src = (fromDevicePlane && contentOrigin ? contentOrigin : "") + viewPath;
   view.appendChild(iframe);
 
   app.innerHTML = "";
@@ -1753,6 +1766,9 @@ function startApp() {
   ])
     .then(([config, slots]) => {
       displaySlots = slots;
+      if (config && config.content_port) {
+        contentOrigin = location.protocol + "//" + location.hostname + ":" + config.content_port;
+      }
       applyTheme(config);
       return render();
     })

--- a/client/app.js
+++ b/client/app.js
@@ -8,8 +8,18 @@ let displayConfig = {};
 // server at GET /display/slots.
 let displaySlots = { renderer: null, home: null, overlay: null };
 // Origin that device-authored surfaces are embedded from (the untrusted content
-// plane). Set at boot from /display/config.content_port; empty = same origin.
+// plane). Set at boot from /display/config; empty = same origin.
 let contentOrigin = "";
+
+// Where a surface's view iframe loads from. Device-authored content must never
+// run on the trusted app origin (its JS would inherit system), so it is embedded
+// from the content origin; system content loads same-origin. Returns null when a
+// device surface has no content origin available, so the caller fails closed with
+// a placeholder instead of silently falling back to the trusted origin.
+function surfaceFrameSrc(fromDevicePlane, contentOrigin, viewPath) {
+  if (fromDevicePlane) return contentOrigin ? contentOrigin + viewPath : null;
+  return viewPath;
+}
 
 async function refreshSlots() {
   try {
@@ -1466,16 +1476,16 @@ async function renderSurface(id) {
   const viewPath = data.view_url || `/artifacts/${id}/view`;
   const meta = parseMetadata(artifact.metadata);
   const fromDevicePlane = meta && meta.author_plane === "device";
-  if (fromDevicePlane && !contentOrigin) {
-    // Fail closed. Device-authored JS must never run on this trusted app origin
-    // (it would inherit system). It belongs on the content plane; if that origin
-    // isn't advertised we refuse to embed rather than silently reopen the hole.
+  const frameSrc = surfaceFrameSrc(fromDevicePlane, contentOrigin, viewPath);
+  if (frameSrc === null) {
+    // Fail closed (see surfaceFrameSrc): a device-authored surface with no
+    // content plane available is NOT rendered on the trusted app origin.
     const warn = document.createElement("div");
     warn.className = "surface-frame surface-frame-unavailable";
     warn.textContent = "This surface needs the isolated content plane, which is unavailable.";
     view.appendChild(warn);
   } else {
-    iframe.src = (fromDevicePlane ? contentOrigin : "") + viewPath;
+    iframe.src = frameSrc;
     view.appendChild(iframe);
   }
 
@@ -1776,7 +1786,9 @@ function startApp() {
   ])
     .then(([config, slots]) => {
       displaySlots = slots;
-      if (config && config.content_port) {
+      if (config && config.content_origin) {
+        contentOrigin = config.content_origin;
+      } else if (config && config.content_port) {
         contentOrigin = location.protocol + "//" + location.hostname + ":" + config.content_port;
       }
       applyTheme(config);

--- a/client/app.js
+++ b/client/app.js
@@ -1466,8 +1466,18 @@ async function renderSurface(id) {
   const viewPath = data.view_url || `/artifacts/${id}/view`;
   const meta = parseMetadata(artifact.metadata);
   const fromDevicePlane = meta && meta.author_plane === "device";
-  iframe.src = (fromDevicePlane && contentOrigin ? contentOrigin : "") + viewPath;
-  view.appendChild(iframe);
+  if (fromDevicePlane && !contentOrigin) {
+    // Fail closed. Device-authored JS must never run on this trusted app origin
+    // (it would inherit system). It belongs on the content plane; if that origin
+    // isn't advertised we refuse to embed rather than silently reopen the hole.
+    const warn = document.createElement("div");
+    warn.className = "surface-frame surface-frame-unavailable";
+    warn.textContent = "This surface needs the isolated content plane, which is unavailable.";
+    view.appendChild(warn);
+  } else {
+    iframe.src = (fromDevicePlane ? contentOrigin : "") + viewPath;
+    view.appendChild(iframe);
+  }
 
   app.innerHTML = "";
   app.appendChild(view);

--- a/client/surface.js
+++ b/client/surface.js
@@ -131,17 +131,31 @@
     return out;
   }
 
-  function action(name, data) {
-    if (window.parent && window.parent !== window) {
-      window.parent.postMessage({ type: "surface_action", action: name, data: data || {} }, "*");
-      return Promise.resolve({ delivered: "bridge" });
-    }
-    // Standalone tab (no PWA bridge): post straight to the server.
+  function postDirect(name, data) {
+    // Post straight to our own origin's actions endpoint. For a device-authored
+    // surface this origin is the content plane, so the action lands as `device`
+    // without ever touching the trusted parent.
     return fetch("/artifacts/" + encodeURIComponent(artifactId) + "/actions", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ action: name, data: data || {} }),
     }).then(function (r) { return r.json(); });
+  }
+
+  function action(name, data) {
+    if (window.parent && window.parent !== window) {
+      // Cross-origin (content-plane) iframe: the parent can't be trusted to
+      // relay, and same-origin bridge access would throw — post directly.
+      var sameOriginParent = true;
+      try { void window.parent.location.origin; } catch (e) { sameOriginParent = false; }
+      if (!sameOriginParent) return postDirect(name, data);
+      // Same-origin (system) iframe: use the PWA bridge so it can update the
+      // "agent listening" UI and route through its own connection.
+      window.parent.postMessage({ type: "surface_action", action: name, data: data || {} }, "*");
+      return Promise.resolve({ delivered: "bridge" });
+    }
+    // Standalone tab (no PWA bridge): post straight to the server.
+    return postDirect(name, data);
   }
 
   // Stage / commit — batch at the surface, not at the agent. Intermediate

--- a/docs/auth/trust-model.md
+++ b/docs/auth/trust-model.md
@@ -55,7 +55,9 @@ Surface serves the **same app from a second listener on `SURFACE_CONTENT_PORT` (
 - The browser's same-origin policy blocks it from reaching the `:3000` API at all.
 - The surface runtime still works there: `GET state`, `GET stream`, `POST actions` are device-plane endpoints. `surface.js` posts actions directly to its own (content) origin rather than relaying through the trusted parent (`client/surface.js`); the PWA's postMessage bridge ignores cross-origin messages (`client/app.js`).
 
-Verified end-to-end in `test/contentOrigin.ts`. Out of scope for now (defense-in-depth): rendering the thumbnailer and display slots via the content origin, and per-remote-host content origins for paired devices (a paired device is already `device`, so it has no system to escalate to).
+The content listener is **mandatory**: if it can't bind (`SURFACE_CONTENT_PORT`, default 3100, already in use), the server refuses to start rather than run with device surfaces unisolated. Behind a reverse proxy or HTTPS terminator where `host:3100` isn't directly reachable, set `SURFACE_CONTENT_ORIGIN` to the externally reachable content origin; the PWA embeds device surfaces from it and **fails closed to a placeholder** when no content origin is available (`client/app.js` `surfaceFrameSrc`), never falling back to the trusted app origin.
+
+Verified end-to-end in `test/contentOrigin.ts` (the port pivot, the boot guards) and `test/appRouting.ts` (the client embedding decision). Out of scope for now (defense-in-depth): rendering the thumbnailer and display slots via the content origin, and per-remote-host content origins for paired devices (a paired device is already `device`, so it has no system to escalate to).
 
 ## `SURFACE_TOKEN` removal
 

--- a/docs/auth/trust-model.md
+++ b/docs/auth/trust-model.md
@@ -43,7 +43,19 @@ The line is drawn at anything that touches the host filesystem, executes code, m
 
 ### Why device artifact CRUD is scoped to device-authored content
 
-Devices can author their own workspace artifacts (a phone jotting a note onto the dashboard), but cannot *modify* artifacts the agent plane created, and cannot mark any artifact as a display slot. Both rules exist because artifact HTML is executed JavaScript: the host display renders slot artifacts directly, and the thumbnailer renders every artifact in headless Chrome over a loopback connection that the server trusts as `system`. If a device could inject script into a system-authored or slot artifact, that script would run with system privileges. Two mechanisms enforce this: every artifact records its authoring plane in server-authoritative `metadata.author_plane` (`server/artifacts.ts` `sealArtifactMetadata`), and the thumbnailer disables JavaScript when rendering device-authored content (`server/thumbs.ts`). A separate, non-loopback content origin for untrusted surfaces remains the longer-term hardening.
+Devices can author their own workspace artifacts (a phone jotting a note onto the dashboard), but cannot *modify* artifacts the agent plane created, and cannot mark any artifact as a display slot. Both rules exist because artifact HTML is executed JavaScript: the host display renders slot artifacts directly, and the thumbnailer renders every artifact in headless Chrome over a loopback connection that the server trusts as `system`. If a device could inject script into a system-authored or slot artifact, that script would run with system privileges. Two mechanisms enforce this: every artifact records its authoring plane in server-authoritative `metadata.author_plane` (`server/artifacts.ts` `sealArtifactMetadata`), and the thumbnailer disables JavaScript when rendering device-authored content (`server/thumbs.ts`). The remaining vector — the host's own browser rendering device content same-origin — is closed by the content plane below.
+
+## The content plane — untrusted origin for device-authored surfaces
+
+The host PWA runs on the app origin (`127.0.0.1:3000`), which is `system`. Surfaces render in iframes, so without isolation a device-authored surface's JavaScript would execute on the trusted origin and could `fetch()` system-only endpoints with system authority just by being displayed — a device→system escalation.
+
+Surface serves the **same app from a second listener on `SURFACE_CONTENT_PORT` (default 3100)** — the content plane. The auth middleware (`server/index.ts`) grants **`device`, never `system`, to every request arriving on the content port**, even over loopback. The PWA embeds **device-authored** surfaces from this origin (chosen by `metadata.author_plane`), while system-authored surfaces stay on the app origin (they are as trusted as the agent that wrote them). Consequences:
+
+- Device JS runs on `:3100`; its same-origin `fetch()`es hit the content plane (`device`) and get 403 on anything system-only.
+- The browser's same-origin policy blocks it from reaching the `:3000` API at all.
+- The surface runtime still works there: `GET state`, `GET stream`, `POST actions` are device-plane endpoints. `surface.js` posts actions directly to its own (content) origin rather than relaying through the trusted parent (`client/surface.js`); the PWA's postMessage bridge ignores cross-origin messages (`client/app.js`).
+
+Verified end-to-end in `test/contentOrigin.ts`. Out of scope for now (defense-in-depth): rendering the thumbnailer and display slots via the content origin, and per-remote-host content origins for paired devices (a paired device is already `device`, so it has no system to escalate to).
 
 ## `SURFACE_TOKEN` removal
 

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "test:thumbs": "tsx test/thumbs.ts",
     "test:runtime": "tsx test/runtime.ts",
     "test:bindings": "tsx test/bindings.ts",
+    "test:content-origin": "tsx test/contentOrigin.ts",
     "test:e2e": "tsx test/e2e.ts"
   },
   "bin": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "test:startup-access": "tsx test/startupAccess.ts",
     "test:thumbs": "tsx test/thumbs.ts",
     "test:runtime": "tsx test/runtime.ts",
+    "test:app-routing": "tsx test/appRouting.ts",
     "test:bindings": "tsx test/bindings.ts",
     "test:content-origin": "tsx test/contentOrigin.ts",
     "test:e2e": "tsx test/e2e.ts"

--- a/server/index.ts
+++ b/server/index.ts
@@ -23,10 +23,19 @@ const BIND = process.env.SURFACE_BIND || "127.0.0.1";
 // docs/auth/trust-model.md and planning/content-origin-scope.md.
 const CONTENT_PORT = Number(process.env.SURFACE_CONTENT_PORT || 3100);
 
-// The content gate keys off the listening port (req.socket.localPort), so the
-// content port MUST be distinct from the app port. If they collide, every
-// request — including the agent plane's own — resolves to `device` and system
-// access silently breaks. Fail fast and loud rather than boot into that state.
+// Both listeners must bind valid, distinct ports. The content gate keys off the
+// listening port (req.socket.localPort), so a collision would resolve every
+// request — including the agent plane's own — to `device`, silently breaking
+// system access. Validate up front and fail fast rather than boot into a broken
+// or de-privileged state.
+function assertPort(name: string, value: number, raw: string | undefined) {
+  if (!Number.isInteger(value) || value < 1 || value > 65535) {
+    console.error(`[startup] ${name} must be an integer in 1..65535 (got ${JSON.stringify(raw)}). Refusing to start.`);
+    process.exit(1);
+  }
+}
+assertPort("PORT", PORT, process.env.PORT);
+assertPort("SURFACE_CONTENT_PORT", CONTENT_PORT, process.env.SURFACE_CONTENT_PORT);
 if (CONTENT_PORT === PORT) {
   console.error(
     `[content-origin] SURFACE_CONTENT_PORT (${CONTENT_PORT}) must differ from PORT (${PORT}): ` +
@@ -195,8 +204,13 @@ const contentServer = app.listen(CONTENT_PORT, BIND, () => {
   console.log(`Surface content origin on http://${BIND}:${CONTENT_PORT} (untrusted device plane)`);
 });
 contentServer.on("error", (err: any) => {
+  // The content plane is the isolation boundary for device-authored surfaces.
+  // If it can't bind, a still-running app would either fail to show those
+  // surfaces or point them at whatever foreign service holds the port — so we
+  // refuse to run degraded. Free the port or set SURFACE_CONTENT_PORT.
   console.error(
     `[content-origin] could not bind ${BIND}:${CONTENT_PORT} (${err?.code || err?.message}). ` +
-    `Device-authored surfaces will fail to load until this port is free or SURFACE_CONTENT_PORT is changed.`,
+    `The content plane isolates device-authored surfaces; refusing to run without it.`,
   );
+  process.exit(1);
 });

--- a/server/index.ts
+++ b/server/index.ts
@@ -17,6 +17,11 @@ import { setThumbServerPort, enqueueThumb, hasThumb, findChromeBin } from "./thu
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const PORT = Number(process.env.PORT || 3000);
 const BIND = process.env.SURFACE_BIND || "127.0.0.1";
+// Second listener serving the same app as the *untrusted content plane*.
+// Device-authored surfaces render from this origin so their JavaScript can
+// never inherit system trust just by being displayed on the host. See
+// docs/auth/trust-model.md and planning/content-origin-scope.md.
+const CONTENT_PORT = Number(process.env.SURFACE_CONTENT_PORT || 3100);
 
 if (process.env.SURFACE_TOKEN) {
   console.warn(
@@ -83,6 +88,16 @@ function isPublicRequest(req: express.Request): boolean {
 // role for downstream system-only checks. Loopback IS the agent plane: same
 // uid, same machine, full power (docs/auth/trust-model.md).
 app.use((req, res, next) => {
+  // The content plane (CONTENT_PORT) is never system, full stop — even over
+  // loopback. Device-authored surface JS runs here, so granting it system would
+  // be the exact escalation this split exists to prevent. Anonymous resolves to
+  // `device` so the surface runtime (state/stream/actions) still works; every
+  // system-only endpoint stays 403.
+  if (req.socket.localPort === CONTENT_PORT) {
+    (req as any).auth = { role: "device", via: "content-port" };
+    return next();
+  }
+
   const remote = req.socket.remoteAddress || "";
   if (TRUST_LOOPBACK && LOOPBACK_ADDRS.has(remote)) {
     (req as any).auth = { role: "system", via: "loopback" };
@@ -160,4 +175,16 @@ const httpServer = app.listen(PORT, BIND, () => {
   } catch (err) {
     console.error("[thumbs] backfill scan failed:", err);
   }
+});
+
+// Content plane: same app, separate origin, never granted system (see the auth
+// middleware above). Device-authored surfaces are embedded from here.
+const contentServer = app.listen(CONTENT_PORT, BIND, () => {
+  console.log(`Surface content origin on http://${BIND}:${CONTENT_PORT} (untrusted device plane)`);
+});
+contentServer.on("error", (err: any) => {
+  console.error(
+    `[content-origin] could not bind ${BIND}:${CONTENT_PORT} (${err?.code || err?.message}). ` +
+    `Device-authored surfaces will fail to load until this port is free or SURFACE_CONTENT_PORT is changed.`,
+  );
 });

--- a/server/index.ts
+++ b/server/index.ts
@@ -23,6 +23,18 @@ const BIND = process.env.SURFACE_BIND || "127.0.0.1";
 // docs/auth/trust-model.md and planning/content-origin-scope.md.
 const CONTENT_PORT = Number(process.env.SURFACE_CONTENT_PORT || 3100);
 
+// The content gate keys off the listening port (req.socket.localPort), so the
+// content port MUST be distinct from the app port. If they collide, every
+// request — including the agent plane's own — resolves to `device` and system
+// access silently breaks. Fail fast and loud rather than boot into that state.
+if (CONTENT_PORT === PORT) {
+  console.error(
+    `[content-origin] SURFACE_CONTENT_PORT (${CONTENT_PORT}) must differ from PORT (${PORT}): ` +
+    `they share one app and a collision would de-privilege the whole server to 'device'. Refusing to start.`,
+  );
+  process.exit(1);
+}
+
 if (process.env.SURFACE_TOKEN) {
   console.warn(
     "[auth] SURFACE_TOKEN is no longer supported and is ignored. " +

--- a/server/routes/display.ts
+++ b/server/routes/display.ts
@@ -71,7 +71,9 @@ displayRouter.get("/stream", (req: any, res) => {
 
 // Get display theme config
 displayRouter.get("/display/config", (_req, res) => {
-  res.json(getDisplayConfig());
+  // content_port tells the PWA which origin to embed device-authored surfaces
+  // from (the untrusted content plane). Read-only, not persisted with theme.
+  res.json({ ...getDisplayConfig(), content_port: Number(process.env.SURFACE_CONTENT_PORT || 3100) });
 });
 
 // Update display theme config. The old raw-HTML slot keys are no longer

--- a/server/routes/display.ts
+++ b/server/routes/display.ts
@@ -71,9 +71,18 @@ displayRouter.get("/stream", (req: any, res) => {
 
 // Get display theme config
 displayRouter.get("/display/config", (_req, res) => {
-  // content_port tells the PWA which origin to embed device-authored surfaces
-  // from (the untrusted content plane). Read-only, not persisted with theme.
-  res.json({ ...getDisplayConfig(), content_port: Number(process.env.SURFACE_CONTENT_PORT || 3100) });
+  // Tells the PWA which origin to embed device-authored surfaces from (the
+  // untrusted content plane). Read-only, not persisted with theme. content_port
+  // is the default (the PWA builds host:port); content_origin pins a full origin
+  // for proxy/HTTPS deployments where the bare host:port isn't reachable.
+  const cfg: Record<string, unknown> = {
+    ...getDisplayConfig(),
+    content_port: Number(process.env.SURFACE_CONTENT_PORT || 3100),
+  };
+  if (process.env.SURFACE_CONTENT_ORIGIN) {
+    cfg.content_origin = process.env.SURFACE_CONTENT_ORIGIN.replace(/\/$/, "");
+  }
+  res.json(cfg);
 });
 
 // Update display theme config. The old raw-HTML slot keys are no longer

--- a/test/appRouting.ts
+++ b/test/appRouting.ts
@@ -1,0 +1,53 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import vm from "node:vm";
+
+// surfaceFrameSrc is the pure decision in client/app.js that keeps
+// device-authored content off the trusted app origin. app.js is a browser script
+// with heavy DOM dependencies, so rather than load the whole file we extract just
+// this function (it has no inner braces) and exercise it in isolation — matching
+// the repo's zero-dep, no-jsdom test convention (see test/runtime.ts).
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const appSrc = fs.readFileSync(path.join(__dirname, "..", "client", "app.js"), "utf8");
+const match = appSrc.match(/function surfaceFrameSrc[\s\S]*?\n\}/);
+if (!match) throw new Error("surfaceFrameSrc not found in client/app.js (did it move or gain inner braces?)");
+
+const sandbox: any = {};
+vm.createContext(sandbox);
+vm.runInContext(match[0] + "\nthis.surfaceFrameSrc = surfaceFrameSrc;", sandbox);
+const surfaceFrameSrc: (device: boolean, origin: string, viewPath: string) => string | null =
+  sandbox.surfaceFrameSrc;
+
+function test(name: string, fn: () => void) {
+  try { fn(); console.log(`  PASS  ${name}`); }
+  catch (err) { console.error(`  FAIL  ${name}`); throw err; }
+}
+
+console.log("\n=== app.js: surfaceFrameSrc (device content stays off the trusted origin) ===\n");
+
+test("system surface loads same-origin (no content-origin prefix)", () => {
+  assert.equal(surfaceFrameSrc(false, "http://h:3100", "/artifacts/x/view"), "/artifacts/x/view");
+});
+
+test("system surface ignores content origin even if one exists", () => {
+  // A system artifact is as trusted as the agent that wrote it; it stays on the
+  // app origin so the postMessage bridge and exec still work.
+  assert.equal(surfaceFrameSrc(false, "", "/artifacts/x/view"), "/artifacts/x/view");
+});
+
+test("device surface loads from the content origin (never the app origin)", () => {
+  assert.equal(
+    surfaceFrameSrc(true, "http://h:3100", "/artifacts/x/view"),
+    "http://h:3100/artifacts/x/view",
+  );
+});
+
+test("device surface with NO content origin fails closed (null → placeholder)", () => {
+  // The one thing that must never happen: device JS rendered on the app origin.
+  assert.equal(surfaceFrameSrc(true, "", "/artifacts/x/view"), null);
+});
+
+console.log("\nsurfaceFrameSrc tests passed\n");

--- a/test/auth.ts
+++ b/test/auth.ts
@@ -118,6 +118,9 @@ function spawnServer(port: number, dataDir: string, env: Record<string, string>)
       SURFACE_BIND: "127.0.0.1",
       SURFACE_PAIR_ON_START: "0",
       PORT: String(port),
+      // Unique content port per spawn so the second listener never collides
+      // with another test server (or the live service) on the default 3100.
+      SURFACE_CONTENT_PORT: String(port + 1000),
       ...env,
     },
     stdio: ["ignore", "pipe", "pipe"],

--- a/test/bindings.ts
+++ b/test/bindings.ts
@@ -101,6 +101,9 @@ async function main() {
       ...process.env,
       SURFACE_DATA_DIR: dataDir,
       PORT: String(PORT),
+      // Unique content port so the (now mandatory) second listener never
+      // collides with another test server or the live service on the default 3100.
+      SURFACE_CONTENT_PORT: String(PORT + 1000),
       SURFACE_BIND: "127.0.0.1",
       SURFACE_PAIR_ON_START: "0",
       NODE_ENV: "test",

--- a/test/contentOrigin.ts
+++ b/test/contentOrigin.ts
@@ -1,0 +1,129 @@
+import assert from "node:assert/strict";
+import { spawn, ChildProcess } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+// End-to-end verification of content-origin isolation. We boot one server with
+// two listeners — the app port (:PORT, loopback = system) and the content port
+// (:CONTENT_PORT, the untrusted device plane) — and prove the pivot: the SAME
+// loopback machine is system on the app port but NEVER system on the content
+// port, while the surface runtime (state/stream/actions) still works there. A
+// device-authored surface served from the content origin therefore can't reach
+// any system-only endpoint, which closes the device→system escalation.
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.join(__dirname, "..");
+const PORT = 35000 + (process.pid % 800);
+const CONTENT_PORT = PORT + 1;
+const APP = `http://127.0.0.1:${PORT}`;
+const CONTENT = `http://127.0.0.1:${CONTENT_PORT}`;
+
+const dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "surface-content-data-"));
+let server: ChildProcess | null = null;
+let serverErr = "";
+
+async function call(base: string, method: string, p: string, body?: unknown) {
+  const res = await fetch(base + p, {
+    method,
+    headers: body !== undefined ? { "Content-Type": "application/json" } : {},
+    body: body !== undefined ? JSON.stringify(body) : undefined,
+    redirect: "manual",
+  });
+  let json: any = null;
+  try { json = await res.clone().json(); } catch {}
+  return { status: res.status, json };
+}
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+async function waitForServer(base: string, timeoutMs: number) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    try { const res = await fetch(base + "/display/config"); if (res.ok) return; } catch {}
+    await sleep(150);
+  }
+  throw new Error(`server did not come up on ${base}\n--- stderr ---\n${serverErr}`);
+}
+
+function test(name: string, fn: () => Promise<void>) {
+  return fn()
+    .then(() => console.log(`  PASS  ${name}`))
+    .catch((err) => { console.error(`  FAIL  ${name}`); throw err; });
+}
+
+async function main() {
+  server = spawn(path.join(repoRoot, "node_modules", ".bin", "tsx"), ["server/index.ts"], {
+    cwd: repoRoot,
+    env: {
+      ...process.env,
+      SURFACE_DATA_DIR: dataDir,
+      PORT: String(PORT),
+      SURFACE_CONTENT_PORT: String(CONTENT_PORT),
+      SURFACE_BIND: "127.0.0.1",
+      SURFACE_PAIR_ON_START: "0",
+      NODE_ENV: "test",
+    },
+    stdio: ["ignore", "ignore", "pipe"],
+  });
+  server.stderr!.setEncoding("utf8");
+  server.stderr!.on("data", (c: string) => { serverErr += c; });
+
+  await waitForServer(APP, 15000);
+  await waitForServer(CONTENT, 15000); // the second listener must be up too
+  console.log("\n=== Content-origin isolation Tests ===\n");
+
+  const id = "content-test-surface";
+
+  await test("setup: a surface exists (created as system on the app port)", async () => {
+    const r = await call(APP, "POST", "/artifacts", {
+      id, title: "Content test", mime: "text/html", content: "<h1>hi</h1>",
+    });
+    assert.equal(r.status, 201, "created on app port");
+  });
+
+  await test("app port from loopback IS system (control)", async () => {
+    const reset = await call(APP, "POST", "/display/reset", {});
+    assert.notEqual(reset.status, 403, "system endpoint allowed on app port");
+    const tpl = await call(APP, "GET", "/api/templates");
+    assert.notEqual(tpl.status, 403, "templates allowed on app port");
+  });
+
+  await test("content port is NEVER system — system-only endpoints 403 (the pivot)", async () => {
+    const reset = await call(CONTENT, "POST", "/display/reset", {});
+    assert.equal(reset.status, 403, "display/reset is 403 on the content port");
+    const tpl = await call(CONTENT, "GET", "/api/templates");
+    assert.equal(tpl.status, 403, "/api/templates is 403 on the content port");
+    const present = await call(CONTENT, "POST", "/artifacts/present-file", { path: "/etc/hosts" });
+    assert.equal(present.status, 403, "file-reading present-file is 403 on the content port");
+  });
+
+  await test("content port still serves the surface runtime (state / actions)", async () => {
+    const state = await call(CONTENT, "GET", `/artifacts/${id}/state`);
+    assert.equal(state.status, 200, "state readable on content port");
+    const act = await call(CONTENT, "POST", `/artifacts/${id}/actions`, { action: "tap", data: { ok: 1 } });
+    assert.equal(act.status, 201, "actions emittable on content port (device plane)");
+  });
+
+  await test("content port serves the artifact view (so it can be embedded)", async () => {
+    const view = await fetch(`${CONTENT}/artifacts/${id}/view`);
+    assert.ok(view.ok || view.status === 200, `view loads on content port (got ${view.status})`);
+  });
+
+  await test("/display/config advertises the content port to the PWA", async () => {
+    const cfg = await call(APP, "GET", "/display/config");
+    assert.equal(cfg.json.content_port, CONTENT_PORT, "content_port advertised");
+  });
+
+  console.log("\nContent-origin tests passed\n");
+}
+
+main()
+  .then(() => { cleanup(); process.exit(0); })
+  .catch((err) => { console.error(err); cleanup(); process.exit(1); });
+
+function cleanup() {
+  try { server?.kill("SIGKILL"); } catch {}
+  try { fs.rmSync(dataDir, { recursive: true, force: true }); } catch {}
+}

--- a/test/contentOrigin.ts
+++ b/test/contentOrigin.ts
@@ -116,6 +116,34 @@ async function main() {
     assert.equal(cfg.json.content_port, CONTENT_PORT, "content_port advertised");
   });
 
+  await test("server refuses to boot when CONTENT_PORT === PORT (collision guard)", async () => {
+    // A collision would make the content gate match the app port too, forcing
+    // every request — including the agent plane's own — to `device`. The server
+    // must fail fast instead of booting into a fully de-privileged state.
+    const samePort = PORT + 5; // exits before any listen, so the value need only collide
+    const guardDataDir = fs.mkdtempSync(path.join(os.tmpdir(), "surface-guard-"));
+    const proc = spawn(path.join(repoRoot, "node_modules", ".bin", "tsx"), ["server/index.ts"], {
+      cwd: repoRoot,
+      env: {
+        ...process.env,
+        SURFACE_DATA_DIR: guardDataDir,
+        PORT: String(samePort),
+        SURFACE_CONTENT_PORT: String(samePort),
+        SURFACE_BIND: "127.0.0.1",
+        SURFACE_PAIR_ON_START: "0",
+        NODE_ENV: "test",
+      },
+      stdio: ["ignore", "ignore", "pipe"],
+    });
+    let err = "";
+    proc.stderr!.setEncoding("utf8");
+    proc.stderr!.on("data", (c: string) => { err += c; });
+    const code: number = await new Promise((resolve) => proc.on("exit", (c) => resolve(c ?? -1)));
+    fs.rmSync(guardDataDir, { recursive: true, force: true });
+    assert.notEqual(code, 0, "process must exit non-zero on port collision");
+    assert.match(err, /must differ from PORT/, "logs the collision reason");
+  });
+
   console.log("\nContent-origin tests passed\n");
 }
 

--- a/test/contentOrigin.ts
+++ b/test/contentOrigin.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import { spawn, ChildProcess } from "node:child_process";
 import fs from "node:fs";
+import net from "node:net";
 import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -61,6 +62,8 @@ async function main() {
       SURFACE_DATA_DIR: dataDir,
       PORT: String(PORT),
       SURFACE_CONTENT_PORT: String(CONTENT_PORT),
+      // A pinned content origin for the proxy-deploy path; advertised verbatim.
+      SURFACE_CONTENT_ORIGIN: "http://content.test:4555",
       SURFACE_BIND: "127.0.0.1",
       SURFACE_PAIR_ON_START: "0",
       NODE_ENV: "test",
@@ -111,9 +114,45 @@ async function main() {
     assert.ok(view.ok || view.status === 200, `view loads on content port (got ${view.status})`);
   });
 
-  await test("/display/config advertises the content port to the PWA", async () => {
+  await test("/display/config advertises the content port (and pinned origin) to the PWA", async () => {
     const cfg = await call(APP, "GET", "/display/config");
     assert.equal(cfg.json.content_port, CONTENT_PORT, "content_port advertised");
+    assert.equal(
+      cfg.json.content_origin,
+      "http://content.test:4555",
+      "pinned SURFACE_CONTENT_ORIGIN advertised for proxy/HTTPS deploys",
+    );
+  });
+
+  await test("server refuses to boot when the content port is taken (content plane is mandatory)", async () => {
+    // The content plane is the isolation boundary; a server with a dead content
+    // listener must not run (it would break or mis-route device surfaces).
+    const appPort = PORT + 10;
+    const takenContentPort = PORT + 11;
+    const squatter = net.createServer();
+    await new Promise<void>((resolve) => squatter.listen(takenContentPort, "127.0.0.1", () => resolve()));
+    const guardDataDir = fs.mkdtempSync(path.join(os.tmpdir(), "surface-bindfail-"));
+    const proc = spawn(path.join(repoRoot, "node_modules", ".bin", "tsx"), ["server/index.ts"], {
+      cwd: repoRoot,
+      env: {
+        ...process.env,
+        SURFACE_DATA_DIR: guardDataDir,
+        PORT: String(appPort),
+        SURFACE_CONTENT_PORT: String(takenContentPort),
+        SURFACE_BIND: "127.0.0.1",
+        SURFACE_PAIR_ON_START: "0",
+        NODE_ENV: "test",
+      },
+      stdio: ["ignore", "ignore", "pipe"],
+    });
+    let err = "";
+    proc.stderr!.setEncoding("utf8");
+    proc.stderr!.on("data", (c: string) => { err += c; });
+    const code: number = await new Promise((resolve) => proc.on("exit", (c) => resolve(c ?? -1)));
+    await new Promise<void>((resolve) => squatter.close(() => resolve()));
+    fs.rmSync(guardDataDir, { recursive: true, force: true });
+    assert.notEqual(code, 0, "process must exit non-zero when the content port can't bind");
+    assert.match(err, /could not bind|content plane/i, "logs why it refused to run");
   });
 
   await test("server refuses to boot when CONTENT_PORT === PORT (collision guard)", async () => {

--- a/test/runtime.ts
+++ b/test/runtime.ts
@@ -14,8 +14,9 @@ const runtimeSrc = fs.readFileSync(path.join(__dirname, "..", "client", "surface
 
 interface FetchCall { url: string; method: string; body: any }
 
-function loadRuntime(cfg: { failActions?: boolean } = {}) {
+function loadRuntime(cfg: { failActions?: boolean; parent?: "self" | "same-origin" | "cross-origin" } = {}) {
   const fetchCalls: FetchCall[] = [];
+  const postMessages: any[] = [];
 
   const fetchMock = (url: string, opts?: any) => {
     fetchCalls.push({
@@ -54,14 +55,32 @@ function loadRuntime(cfg: { failActions?: boolean } = {}) {
     setTimeout,
     clearTimeout,
   };
-  // window IS the global, and window.parent === window (standalone-tab path → fetch).
+  // window IS the global. The parent decides how action() routes:
+  //   self         → no parent frame; post straight to the server (standalone tab)
+  //   same-origin  → trusted system iframe; relay through the PWA postMessage bridge
+  //   cross-origin → content-plane iframe; reading parent.location throws, so post direct
   sandbox.window = sandbox;
-  sandbox.window.parent = sandbox.window;
+  const parentMode = cfg.parent || "self";
+  if (parentMode === "self") {
+    sandbox.window.parent = sandbox.window;
+  } else if (parentMode === "same-origin") {
+    sandbox.window.parent = {
+      location: { origin: "http://localhost" },
+      postMessage: (msg: any) => { postMessages.push(msg); },
+    };
+  } else {
+    const crossParent: any = { postMessage: (msg: any) => { postMessages.push(msg); } };
+    // Touching .location on a cross-origin window throws a SecurityError; mirror that.
+    Object.defineProperty(crossParent, "location", {
+      get() { throw new Error("SecurityError: cross-origin"); },
+    });
+    sandbox.window.parent = crossParent;
+  }
 
   vm.createContext(sandbox);
   vm.runInContext(runtimeSrc, sandbox);
 
-  return { Surface: sandbox.window.Surface, fetchCalls };
+  return { Surface: sandbox.window.Surface, fetchCalls, postMessages };
 }
 
 function test(name: string, fn: () => void | Promise<void>) {
@@ -157,6 +176,26 @@ await test("a FAILED commit preserves staged data (intent is not lost)", async (
     { region: "eu-west", plan: "pro" },
     "staged retained after a server rejection — the user can retry",
   );
+});
+
+await test("cross-origin (content-plane) parent → action posts DIRECT, never via the bridge", async () => {
+  const { Surface, fetchCalls, postMessages } = loadRuntime({ parent: "cross-origin" });
+  await Surface.action("tap", { x: 1 });
+  const posts = actionsPosts(fetchCalls);
+  assert.equal(posts.length, 1, "device surface posts its action to its own (content) origin");
+  assert.equal(posts[0].body.action, "tap");
+  assert.deepEqual(plain(posts[0].body.data), { x: 1 });
+  assert.equal(postMessages.length, 0, "it must NOT relay through the trusted parent");
+});
+
+await test("same-origin (system) parent → action uses the bridge, no direct POST", async () => {
+  const { Surface, fetchCalls, postMessages } = loadRuntime({ parent: "same-origin" });
+  await Surface.action("tap", { x: 1 });
+  assert.equal(actionsPosts(fetchCalls).length, 0, "system surface relays, does not POST itself");
+  assert.equal(postMessages.length, 1, "exactly one bridge message");
+  assert.equal(postMessages[0].type, "surface_action");
+  assert.equal(postMessages[0].action, "tap");
+  assert.deepEqual(plain(postMessages[0].data), { x: 1 });
 });
 
 console.log("\nRuntime tests passed\n");


### PR DESCRIPTION
## What

Closes the last path in the device→system escalation class: **device-authored surface content executing same-origin in the host's trusted (loopback = system) browser**. Implements Phase 1 of `planning/content-origin-scope.md`.

### The hole
The host PWA runs on the app origin (`127.0.0.1:3000`), which the auth middleware trusts as `system` (any loopback request). Surfaces render in iframes, so a **device**-authored surface's JS, once the host opens it, `fetch()`es system-only endpoints with system authority — just by being displayed. Prior fixes plugged the thumbnailer (JS disabled for device content) and slot/CRUD vectors via `author_plane`; this was the residual.

### The fix
Serve the same app from a **second listener** on `SURFACE_CONTENT_PORT` (default `3100`) — the untrusted content plane:

- **Trust gate (the pivot):** every request arriving on the content port resolves to `device`, **never `system`**, even over loopback (`server/index.ts`).
- The PWA embeds **device**-authored surfaces from the content origin (chosen by `metadata.author_plane`); **system**-authored surfaces stay on the app origin, as trusted as the agent that wrote them (`client/app.js`).
- `surface.js` posts actions **directly to its own (content) origin** when it's a cross-origin iframe, instead of relaying through the trusted parent; the PWA's postMessage bridge now ignores cross-origin messages (`client/surface.js`, `client/app.js`).
- The surface runtime keeps working on the content plane — `state` / `stream` / `actions` are device-plane endpoints.

Net effect: device JS runs on `:3100`, its `fetch()`es hit the content plane (403 on anything privileged), and same-origin policy blocks it from reaching the `:3000` API at all. System content is unaffected.

## Testing
- New `test/contentOrigin.ts` (`npm run test:content-origin`) boots the real two-listener server and proves the pivot end-to-end: loopback is `system` on the app port but gets **403 on system-only endpoints (`/display/reset`, `/api/templates`, `present-file`) on the content port**, while `state`/`actions`/`view` still work there, and `/display/config` advertises the content port.
- `test/auth.ts` updated to give each spawned server a unique content port; **47/47 still pass.**
- Full suite green (`runtime`, `bindings`, `thumbs`, `startup-access`), `tsc --noEmit` clean.
- Live smoke confirmed device `/view` → `/files/index.html` loads with `surface.js` injected on `:3100`.

## Deploy note
The live service must be restarted after merge to open `:3100`, and that port needs to be free (configurable via `SURFACE_CONTENT_PORT`). Out of scope (Phase 2, documented in `docs/auth/trust-model.md`): thumbnailer/slots via the content origin, per-remote-host content origins.