### PR TITLE
Add surface upgrade and surface skill install

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,12 @@ All notable changes to Surface are recorded here.
   no longer aborts `surface upgrade` halfway (reported, everything else still
   converges, exit 1); a cleanly stopped service is left stopped instead of
   being started by `upgrade`.
+- User-edited skills are never clobbered: `install-state.json` records the
+  hash of the `SKILL.md` Surface last wrote (`skill_sha256`), so upgrades can
+  tell their own stale copies (converged as before) from local edits (kept,
+  mirrored to every link/copy, reported as `edited` by `skill install`,
+  `upgrade`, `--check`, and `service health`). `surface skill install
+  --force` replaces an edit with the packaged skill.
 - `surface service health` now also flags a stale/missing skill copy, and the
   CLI prints an actionable "service unreachable — is it running?" hint (with
   the install one-liner) instead of a bare `fetch failed` when the service is

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,9 @@ All notable changes to Surface are recorded here.
   `service health`), and state writes are atomic; one unwritable skill target
   no longer aborts `surface upgrade` halfway (reported, everything else still
   converges, exit 1); a cleanly stopped service is left stopped instead of
-  being started by `upgrade`.
+  being started by `upgrade`; an unrecorded `surface` symlink pointing at a
+  non-Surface skill is skipped, never repointed; and `upgrade --json` keeps
+  npm's install output off stdout so the report stays machine-parsable.
 - User-edited skills are never clobbered: `install-state.json` records the
   hash of the `SKILL.md` Surface last wrote (`skill_sha256`), so upgrades can
   tell their own stale copies (converged as before) from local edits (kept,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,18 @@ All notable changes to Surface are recorded here.
   open standard read by Codex, Cursor, Gemini CLI, Copilot, Zed, Amp, Goose,
   OpenCode, Roo, Kilo, Windsurf — and `~/.claude/skills/` for Claude Code.
   `--to` adds harness-native dirs; targets are recorded in
-  `install-state.json` and refreshed by `surface upgrade`. Never touches a
-  skill directory containing files it doesn't own.
+  `install-state.json` and refreshed by `surface upgrade`. `--copy`/`--link`
+  set the mode for the run's targets and are remembered per target. Never
+  touches a skill directory containing files it doesn't own; a lone
+  non-Surface `SKILL.md` is skipped too (only legacy Surface copies are
+  adopted).
+- Upgrade/skill hardening (review findings): the registry-reported version is
+  semver-validated before it reaches `npm install`; the canonical skill and
+  `install-state.json` live in the service's saved data dir (matching
+  `service health`), and state writes are atomic; one unwritable skill target
+  no longer aborts `surface upgrade` halfway (reported, everything else still
+  converges, exit 1); a cleanly stopped service is left stopped instead of
+  being started by `upgrade`.
 - `surface service health` now also flags a stale/missing skill copy, and the
   CLI prints an actionable "service unreachable — is it running?" hint (with
   the install one-liner) instead of a bare `fetch failed` when the service is

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,33 @@
 
 All notable changes to Surface are recorded here.
 
+## Unreleased
+
+- New `surface upgrade`: one command that updates `surface-display` to the
+  latest npm release (global installs; dev/local installs get advice instead),
+  refreshes the canonical skill copy plus every recorded skill link, and
+  restarts the service only when it is running an older version
+  (health-gated). `--check` reports without changing anything;
+  `surface service update`/`upgrade` redirect here.
+- New `surface skill install`: keeps one canonical `SKILL.md` at
+  `<data-dir>/skills/surface/` and links it (junction on Windows, managed copy
+  where symlinks are forbidden) into `~/.agents/skills/` — the agentskills.io
+  open standard read by Codex, Cursor, Gemini CLI, Copilot, Zed, Amp, Goose,
+  OpenCode, Roo, Kilo, Windsurf — and `~/.claude/skills/` for Claude Code.
+  `--to` adds harness-native dirs; targets are recorded in
+  `install-state.json` and refreshed by `surface upgrade`. Never touches a
+  skill directory containing files it doesn't own.
+- `surface service health` now also flags a stale/missing skill copy, and the
+  CLI prints an actionable "service unreachable — is it running?" hint (with
+  the install one-liner) instead of a bare `fetch failed` when the service is
+  down.
+- SKILL.md two-way-loop addition: "state is a claim, not an animation" — never
+  patch a status/progress/"running…" for work not actually executed or
+  observed.
+- INSTALL_FOR_AGENTS.md: skill installation and upgrading rewritten around the
+  two new commands; per-harness skill directory list verified against vendor
+  docs (2026-07).
+
 ## 0.2.2 - 2026-07-07
 
 - Fixed Windows `surface service stop`/`uninstall` leaving the server

--- a/INSTALL_FOR_AGENTS.md
+++ b/INSTALL_FOR_AGENTS.md
@@ -85,9 +85,10 @@ surface skill install
 ```
 
 One command. It keeps a canonical copy at `<data-dir>/skills/surface/SKILL.md`
-(data dir is `~/.surface` unless `SURFACE_DATA_DIR` is set) and links it —
-directory symlink, junction on Windows — into the two locations that cover
-almost every harness (paths verified against vendor docs, 2026-07):
+(the service's data dir: the one saved by `surface service install`, else
+`SURFACE_DATA_DIR`, else `~/.surface`) and links it — directory symlink,
+junction on Windows — into the two locations that cover almost every harness
+(paths verified against vendor docs, 2026-07):
 
 - `~/.agents/skills/surface/` — the neutral open standard (agentskills.io),
   read by Codex, Cursor, Gemini CLI, Copilot, Zed, Amp, Goose, OpenCode, Roo,
@@ -99,11 +100,16 @@ Because they are links to one canonical copy, `surface upgrade` refreshes the
 skill everywhere at once. Where symlinks aren't permitted it falls back to
 managed copies and records them, so upgrades rewrite those too. It stamps
 `skill_saved_to` and `skill_links` in the state file for you — no manual
-bookkeeping. It never touches a skill directory containing files it doesn't
-own. Idempotent; re-run any time.
+bookkeeping. Ownership rules: a skill directory containing anything besides a
+`SKILL.md` is never touched; a directory holding only a *Surface* `SKILL.md`
+(frontmatter `name: surface` — the legacy manual copies older instructions
+created) is adopted and upgraded to a link; a lone non-Surface `SKILL.md` is
+skipped. Idempotent; re-run any time.
 
-Your harness reads its own directory instead? Add it with `--to` (repeatable;
-`--copy` forces copies over links):
+Your harness reads its own directory instead? Add it with `--to` (repeatable).
+`--copy` / `--link` set copies-vs-links for the run's targets (the `--to`
+dirs, or the two defaults when no `--to` is given); each target's mode is
+remembered per target and kept by later runs and `surface upgrade`:
 
 ```bash
 surface skill install --to ~/.cline/skills
@@ -217,8 +223,10 @@ One command, three legs: updates `surface-display` to the latest npm release
 (global installs only — it detects and skips repo clones and project-local
 installs with advice), refreshes the canonical `SKILL.md` plus every recorded
 skill link/copy, and restarts the service if it is running an older version
-(health-gated). It is a converger — safe to run any time, including to finish
-a manual `npm update -g` someone ran without it.
+(health-gated; a cleanly stopped service is left stopped). It is a converger —
+safe to run any time, including to finish a manual `npm update -g` someone ran
+without it. A skill target that can't be written is reported and skipped (exit
+1 after everything else converges), never allowed to abort the run halfway.
 
 `surface upgrade --check` reports without changing anything. `surface service
 health` prints a note whenever the package, the running service, or the skill

--- a/INSTALL_FOR_AGENTS.md
+++ b/INSTALL_FOR_AGENTS.md
@@ -105,7 +105,8 @@ bookkeeping. Ownership rules: a skill directory containing anything besides a
 `SKILL.md` is never touched; a directory holding only a *Surface* `SKILL.md`
 (frontmatter `name: surface` — the legacy manual copies older instructions
 created) is adopted and upgraded to a link; a lone non-Surface `SKILL.md` is
-skipped. A canonical copy the user edited is kept — and mirrored to every
+skipped; an existing symlink is only repointed when it is recorded as ours or
+resolves to a Surface skill. A canonical copy the user edited is kept — and mirrored to every
 link and managed copy — until `surface skill install --force` replaces it
 with the packaged skill (`service health` reports it as `edited`).
 Idempotent; re-run any time.

--- a/INSTALL_FOR_AGENTS.md
+++ b/INSTALL_FOR_AGENTS.md
@@ -12,6 +12,7 @@ Install state lives outside the repo so the working tree stays clean:
 {
   "service": "pending",
   "skill_saved_to": null,
+  "skill_sha256": null,
   "tutorial": "pending",
   "surface_version": null,
   "installed_at": null,
@@ -20,7 +21,7 @@ Install state lives outside the repo so the working tree stays clean:
 ```
 
 - `service`: `pending | running | not_installed | failed` — is the Surface service reachable on `127.0.0.1:3000`?
-- `skill_saved_to`: the canonical `SKILL.md` copy (stamped by `surface skill install`, which also records its links under `skill_links`).
+- `skill_saved_to`: the canonical `SKILL.md` copy (stamped by `surface skill install`, which also records its links under `skill_links` and the hash of what it wrote under `skill_sha256` — never set these by hand; they are how upgrades tell their own stale copies from user edits).
 - `tutorial`: `pending | in_progress | complete | skipped`.
 - `surface_version`, `installed_at`: stamped on first complete install.
 - `notes`: anything the next agent should know.
@@ -104,7 +105,10 @@ bookkeeping. Ownership rules: a skill directory containing anything besides a
 `SKILL.md` is never touched; a directory holding only a *Surface* `SKILL.md`
 (frontmatter `name: surface` — the legacy manual copies older instructions
 created) is adopted and upgraded to a link; a lone non-Surface `SKILL.md` is
-skipped. Idempotent; re-run any time.
+skipped. A canonical copy the user edited is kept — and mirrored to every
+link and managed copy — until `surface skill install --force` replaces it
+with the packaged skill (`service health` reports it as `edited`).
+Idempotent; re-run any time.
 
 Your harness reads its own directory instead? Add it with `--to` (repeatable).
 `--copy` / `--link` set copies-vs-links for the run's targets (the `--to`
@@ -226,7 +230,9 @@ skill link/copy, and restarts the service if it is running an older version
 (health-gated; a cleanly stopped service is left stopped). It is a converger —
 safe to run any time, including to finish a manual `npm update -g` someone ran
 without it. A skill target that can't be written is reported and skipped (exit
-1 after everything else converges), never allowed to abort the run halfway.
+1 after everything else converges), never allowed to abort the run halfway. A
+user-edited skill is kept, reported as `edited` — upgrade converges versions,
+not opinions; only `surface skill install --force` replaces the edit.
 
 `surface upgrade --check` reports without changing anything. `surface service
 health` prints a note whenever the package, the running service, or the skill

--- a/INSTALL_FOR_AGENTS.md
+++ b/INSTALL_FOR_AGENTS.md
@@ -20,7 +20,7 @@ Install state lives outside the repo so the working tree stays clean:
 ```
 
 - `service`: `pending | running | not_installed | failed` — is the Surface service reachable on `127.0.0.1:3000`?
-- `skill_saved_to`: where you copied `SKILL.md` into your own skills directory.
+- `skill_saved_to`: the canonical `SKILL.md` copy (stamped by `surface skill install`, which also records its links under `skill_links`).
 - `tutorial`: `pending | in_progress | complete | skipped`.
 - `surface_version`, `installed_at`: stamped on first complete install.
 - `notes`: anything the next agent should know.
@@ -78,24 +78,52 @@ If the user declines: set `service: "not_installed"` and stop. Don't proceed wit
 
 > **Note (fresh-start schema, 2026-06):** the first boot of a current build archives any pre-existing database to `~/.surface/db.sqlite.bak` and starts clean. Surfaces from older versions are not migrated — re-link or re-create them (`surface sync` recreates anything a project declared in `.surface/`).
 
-## Step 2 — Save SKILL.md to your skills directory
-
-`SKILL.md` ships inside the installed package (`"$(npm root -g)/surface-display/SKILL.md"`; repo root if you're working from a clone). Copy it into your own agent's skill directory so you can read it on future sessions.
-
-Known agent skill directories:
-
-- **Claude Code**: `~/.claude/skills/surface/SKILL.md`
-- **Cursor**: `~/.cursor/skills/surface/SKILL.md` (or workspace `.cursor/skills/`)
-- **Generic**: whatever path your agent uses for ambient skills
+## Step 2 — Install SKILL.md into your skills directory
 
 ```bash
-mkdir -p ~/.claude/skills/surface
-cp "$(npm root -g)/surface-display/SKILL.md" ~/.claude/skills/surface/SKILL.md
+surface skill install
 ```
 
-Set `skill_saved_to: "<absolute path>"`.
+One command. It keeps a canonical copy at `<data-dir>/skills/surface/SKILL.md`
+(data dir is `~/.surface` unless `SURFACE_DATA_DIR` is set) and links it —
+directory symlink, junction on Windows — into the two locations that cover
+almost every harness (paths verified against vendor docs, 2026-07):
 
-If the agent has no skills directory convention, document the path in `notes` and read `SKILL.md` from the repo on every session.
+- `~/.agents/skills/surface/` — the neutral open standard (agentskills.io),
+  read by Codex, Cursor, Gemini CLI, Copilot, Zed, Amp, Goose, OpenCode, Roo,
+  Kilo, and Windsurf.
+- `~/.claude/skills/surface/` — Claude Code (it does **not** read
+  `~/.agents/`).
+
+Because they are links to one canonical copy, `surface upgrade` refreshes the
+skill everywhere at once. Where symlinks aren't permitted it falls back to
+managed copies and records them, so upgrades rewrite those too. It stamps
+`skill_saved_to` and `skill_links` in the state file for you — no manual
+bookkeeping. It never touches a skill directory containing files it doesn't
+own. Idempotent; re-run any time.
+
+Your harness reads its own directory instead? Add it with `--to` (repeatable;
+`--copy` forces copies over links):
+
+```bash
+surface skill install --to ~/.cline/skills
+```
+
+Native global dirs, for reference — every non-Claude harness here also reads
+`~/.agents/skills/`, so `--to` is rarely needed: Cursor
+`~/.cursor/skills/`, Copilot (VS Code) `~/.copilot/skills/`, Gemini CLI
+`~/.gemini/skills/`, Windsurf `~/.codeium/windsurf/skills/`, Cline
+`~/.cline/skills/` (off by default — enable Settings → Features → Skills,
+v3.48+), Roo Code `~/.roo/skills/`, Kilo Code `~/.kilo/skills/` (`.kilo`, not
+`.kilocode`), OpenCode `~/.config/opencode/skills/`, Goose
+`~/.config/goose/skills/`, Amp `~/.config/agents/skills/`. Project-scoped:
+the repo-relative equivalents (`.agents/skills/`, `.claude/skills/`, …) via
+`--to`.
+
+No skills convention (e.g. Aider)? Append a one-line pointer to the canonical
+copy in your agent's instructions file (`AGENTS.md`, `CLAUDE.md`, `GEMINI.md`,
+`.github/copilot-instructions.md`, Aider's `CONVENTIONS.md`), record the path
+in `notes`, and read `SKILL.md` from there on every session.
 
 ## Step 3 — Tutorial
 
@@ -182,16 +210,23 @@ Per-surface webhooks (with retry) are usually better: `surface bind <id> --webho
 ## Upgrading
 
 ```bash
-npm update -g surface-display
-surface service restart      # health-gated; the service keeps running old code until restarted
-surface service health       # warns if CLI and service versions still diverge
+surface upgrade
 ```
 
-Re-copy `SKILL.md` to the path recorded in `skill_saved_to` after upgrading —
-`surface service health` catching a version change is your cue.
+One command, three legs: updates `surface-display` to the latest npm release
+(global installs only — it detects and skips repo clones and project-local
+installs with advice), refreshes the canonical `SKILL.md` plus every recorded
+skill link/copy, and restarts the service if it is running an older version
+(health-gated). It is a converger — safe to run any time, including to finish
+a manual `npm update -g` someone ran without it.
+
+`surface upgrade --check` reports without changing anything. `surface service
+health` prints a note whenever the package, the running service, or the skill
+copies drift — that note is your cue.
 
 (Repo clone instead: `git pull && npm install && npm test`, then
-`surface service restart`.)
+`surface upgrade` — it skips the npm step but still converges skill and
+service.)
 
 Ask before restarting if the user has active work on the display.
 

--- a/STATUS.md
+++ b/STATUS.md
@@ -60,6 +60,13 @@ bash scripts/check-leaks.sh
 ## Operational Notes
 
 - Data lives in `~/.surface/` unless `SURFACE_DATA_DIR` is set.
+- Skill distribution (2026-07-07): `surface skill install` keeps the canonical
+  `SKILL.md` at `<data-dir>/skills/surface/` and symlinks/junctions it into
+  `~/.agents/skills/` (agentskills.io open standard) + `~/.claude/skills/`
+  (Claude Code reads only its own dir); `surface upgrade` converges package →
+  skill → service in one command. Chosen over `npx skills add` (tracks git
+  master — breaks the version lock between skill text and installed binary)
+  and over linking into `$(npm root -g)` (dangles when nvm switches node).
 - The service is intended to run once as a per-user supervised service bound
   to `127.0.0.1` (`surface service install`; see Distribution above).
 - Pre-baseline SQLite databases are archived to `db.sqlite.bak` at boot and are not row-migrated.

--- a/STATUS.md
+++ b/STATUS.md
@@ -75,7 +75,9 @@ bash scripts/check-leaks.sh
   everything else converges), `--copy`/`--link` modes are per-target sticky
   (scope = `--to` dirs, else defaults), and a lone SKILL.md is only adopted
   when it is a Surface skill (`name: surface` frontmatter) or already
-  recorded as ours.
+  recorded as ours. User edits to the canonical SKILL.md are hash-guarded
+  (`skill_sha256` in install-state): kept and mirrored everywhere until
+  `surface skill install --force`; health reports `edited` vs `stale`.
 - The service is intended to run once as a per-user supervised service bound
   to `127.0.0.1` (`surface service install`; see Distribution above).
 - Pre-baseline SQLite databases are archived to `db.sqlite.bak` at boot and are not row-migrated.

--- a/STATUS.md
+++ b/STATUS.md
@@ -67,6 +67,15 @@ bash scripts/check-leaks.sh
   skill → service in one command. Chosen over `npx skills add` (tracks git
   master — breaks the version lock between skill text and installed binary)
   and over linking into `$(npm root -g)` (dangles when nvm switches node).
+  Hardened after a two-reviewer pass (Codex high-effort + Opus, 2026-07-07):
+  skill dir follows the service's *saved* data dir (matching `service
+  health`), registry version is semver-gated before `npm install` (Windows
+  `shell:true` injection), a cleanly stopped service is never started by
+  `upgrade`, per-target failures don't abort the converger (exit 1 after
+  everything else converges), `--copy`/`--link` modes are per-target sticky
+  (scope = `--to` dirs, else defaults), and a lone SKILL.md is only adopted
+  when it is a Surface skill (`name: surface` frontmatter) or already
+  recorded as ours.
 - The service is intended to run once as a per-user supervised service bound
   to `127.0.0.1` (`surface service install`; see Distribution above).
 - Pre-baseline SQLite databases are archived to `db.sqlite.bak` at boot and are not row-migrated.

--- a/STATUS.md
+++ b/STATUS.md
@@ -75,7 +75,8 @@ bash scripts/check-leaks.sh
   everything else converges), `--copy`/`--link` modes are per-target sticky
   (scope = `--to` dirs, else defaults), and a lone SKILL.md is only adopted
   when it is a Surface skill (`name: surface` frontmatter) or already
-  recorded as ours. User edits to the canonical SKILL.md are hash-guarded
+  recorded as ours — same rule for repointing an existing symlink. `upgrade
+  --json` captures npm's install output so stdout stays pure JSON. User edits to the canonical SKILL.md are hash-guarded
   (`skill_sha256` in install-state): kept and mirrored everywhere until
   `surface skill install --force`; health reports `edited` vs `stale`.
 - The service is intended to run once as a per-user supervised service bound

--- a/bin/service.ts
+++ b/bin/service.ts
@@ -1,4 +1,5 @@
 import { spawnSync } from "child_process";
+import { createHash } from "crypto";
 import fs from "fs";
 import net from "net";
 import os from "os";
@@ -560,12 +561,24 @@ function resolveConfig(flags: Record<string, string | boolean>): ServiceConfig {
 }
 
 // Is the skill copy agents read in sync with the package's SKILL.md?
-function skillCopyState(cfg: ServiceConfig): { path: string; state: "ok" | "stale" | "missing" | "unknown" } {
+// "stale" = provably our old content (hash matches skill_sha256 in
+// install-state — upgrade will converge it); "edited" = the user changed it
+// (or its provenance is unknown) — upgrade keeps it.
+function skillCopyState(cfg: ServiceConfig): { path: string; state: "ok" | "stale" | "edited" | "missing" | "unknown" } {
   const copy = path.join(cfg.dataDir, "skills", "surface", "SKILL.md");
   try {
     const pkgSkill = fs.readFileSync(path.join(__dirname, "..", "SKILL.md"));
     if (!fs.existsSync(copy)) return { path: copy, state: "missing" };
-    return { path: copy, state: fs.readFileSync(copy).equals(pkgSkill) ? "ok" : "stale" };
+    const cur = fs.readFileSync(copy);
+    if (cur.equals(pkgSkill)) return { path: copy, state: "ok" };
+    let recorded: unknown;
+    try {
+      recorded = JSON.parse(fs.readFileSync(path.join(cfg.dataDir, "install-state.json"), "utf8")).skill_sha256;
+    } catch {
+      // no state file — unknown provenance
+    }
+    const mine = createHash("sha256").update(cur).digest("hex");
+    return { path: copy, state: recorded === mine ? "stale" : "edited" };
   } catch {
     return { path: copy, state: "unknown" };
   }
@@ -721,6 +734,8 @@ export async function runService({ positional, flags }: ServiceCtx): Promise<voi
         // Same blind spot for the skill: the copy agents read must match the package.
         if (skill.state === "stale" || skill.state === "missing") {
           console.error(`note: skill copy at ${skill.path} is ${skill.state} — run: surface upgrade (or: surface skill install)`);
+        } else if (skill.state === "edited") {
+          console.error(`note: skill copy at ${skill.path} is locally edited — kept; surface skill install --force replaces it`);
         }
       }
       process.exit(health.ok ? 0 : 1);

--- a/bin/service.ts
+++ b/bin/service.ts
@@ -349,7 +349,7 @@ export interface HealthReport {
   error?: string;
 }
 
-function localVersion(): string {
+export function localVersion(): string {
   try {
     const pkg = JSON.parse(fs.readFileSync(path.join(__dirname, "..", "package.json"), "utf8"));
     return String(pkg.version || "unknown");
@@ -552,8 +552,45 @@ function resolveConfig(flags: Record<string, string | boolean>): ServiceConfig {
   };
 }
 
+// Is the skill copy agents read in sync with the package's SKILL.md?
+function skillCopyState(cfg: ServiceConfig): { path: string; state: "ok" | "stale" | "missing" | "unknown" } {
+  const copy = path.join(cfg.dataDir, "skills", "surface", "SKILL.md");
+  try {
+    const pkgSkill = fs.readFileSync(path.join(__dirname, "..", "SKILL.md"));
+    if (!fs.existsSync(copy)) return { path: copy, state: "missing" };
+    return { path: copy, state: fs.readFileSync(copy).equals(pkgSkill) ? "ok" : "stale" };
+  } catch {
+    return { path: copy, state: "unknown" };
+  }
+}
+
+// Converge the running service onto the installed package version: restart
+// only when a service is registered AND it reports a different version than
+// this CLI (the post-`npm update -g` blind spot). Used by `surface upgrade`.
+export async function restartServiceIfStale(
+  timeoutSec = 20,
+  name?: string,
+): Promise<{ installed: boolean; restarted: boolean; version?: string; error?: string }> {
+  const cfg = resolveConfig(name ? { name } : {});
+  const st = backend().status(cfg);
+  if (!st.registered) return { installed: false, restarted: false };
+  const mine = localVersion();
+  const before = await checkHealth(cfg.port, healthHost(cfg.bind));
+  if (before.ok && mine !== "unknown" && before.version === mine) {
+    return { installed: true, restarted: false, version: before.version };
+  }
+  backend().restart(cfg);
+  const health = await waitHealthy(cfg.port, timeoutSec, healthHost(cfg.bind));
+  if (!health.ok) return { installed: true, restarted: true, error: String(health.error) };
+  return { installed: true, restarted: true, version: health.version };
+}
+
 export async function runService({ positional, flags }: ServiceCtx): Promise<void> {
   const sub = positional[0];
+  if (sub === "update" || sub === "upgrade") {
+    console.error("did you mean: surface upgrade — updates the package, refreshes the skill, and restarts the service");
+    process.exit(2);
+  }
   const subs = ["install", "uninstall", "start", "stop", "restart", "status", "health", "logs"];
   if (!sub || !subs.includes(sub)) {
     console.error(`usage:\n${SERVICE_HELP}`);
@@ -650,17 +687,24 @@ export async function runService({ positional, flags }: ServiceCtx): Promise<voi
     }
     case "health": {
       const health = await checkHealth(cfg.port, healthHost(cfg.bind));
+      const mine = localVersion();
+      const skill = skillCopyState(cfg);
       if (json) {
-        console.log(JSON.stringify(health, null, 2));
+        console.log(JSON.stringify({ ...health, cli_version: mine, skill_copy: skill.path, skill_copy_state: skill.state }, null, 2));
       } else if (health.ok) {
         console.log(`healthy: Surface ${health.version} on :${health.port} (content :${health.content_port}), pid ${health.pid}, up ${health.uptime_seconds}s`);
       } else {
         console.error(`unhealthy: ${health.error} (${health.url})`);
       }
-      // The npm-upgrade blind spot: package updated, service still running old code.
-      const mine = localVersion();
-      if (health.ok && mine !== "unknown" && health.version !== mine) {
-        console.error(`note: this CLI is ${mine} but the running service is ${health.version} — run: surface service restart`);
+      if (!json) {
+        // The npm-upgrade blind spot: package updated, service still running old code.
+        if (health.ok && mine !== "unknown" && health.version !== mine) {
+          console.error(`note: this CLI is ${mine} but the running service is ${health.version} — run: surface upgrade`);
+        }
+        // Same blind spot for the skill: the copy agents read must match the package.
+        if (skill.state === "stale" || skill.state === "missing") {
+          console.error(`note: skill copy at ${skill.path} is ${skill.state} — run: surface upgrade (or: surface skill install)`);
+        }
       }
       process.exit(health.ok ? 0 : 1);
     }

--- a/bin/service.ts
+++ b/bin/service.ts
@@ -505,6 +505,13 @@ function loadSavedConfig(name: string): SavedConfig {
   }
 }
 
+// The skill/upgrade side (bin/upgrade.ts) anchors the canonical SKILL.md in
+// the same data dir the service actually uses — saved config beats
+// SURFACE_DATA_DIR, matching resolveConfig below.
+export function savedServiceDataDir(name = "surface"): string | undefined {
+  return loadSavedConfig(name).dataDir;
+}
+
 export function saveServiceConfig(cfg: ServiceConfig): void {
   const file = savedConfigPath(cfg.name);
   fs.mkdirSync(path.dirname(file), { recursive: true });
@@ -564,16 +571,26 @@ function skillCopyState(cfg: ServiceConfig): { path: string; state: "ok" | "stal
   }
 }
 
+// Supervisor states that mean "an operator stopped this on purpose":
+// systemd `inactive`, launchd unloaded (stop = bootout), Scheduled Task
+// Ready/Disabled. Crashed/hung states are NOT here — those still restart.
+const STOPPED_STATES = new Set(["inactive", "not loaded", "ready", "disabled"]);
+
 // Converge the running service onto the installed package version: restart
 // only when a service is registered AND it reports a different version than
-// this CLI (the post-`npm update -g` blind spot). Used by `surface upgrade`.
+// this CLI (the post-`npm update -g` blind spot). A cleanly stopped service
+// stays stopped — upgrade converges versions, it never overrides an
+// operator's stop. Used by `surface upgrade`.
 export async function restartServiceIfStale(
   timeoutSec = 20,
   name?: string,
-): Promise<{ installed: boolean; restarted: boolean; version?: string; error?: string }> {
+): Promise<{ installed: boolean; restarted: boolean; version?: string; state?: string; error?: string }> {
   const cfg = resolveConfig(name ? { name } : {});
   const st = backend().status(cfg);
   if (!st.registered) return { installed: false, restarted: false };
+  if (STOPPED_STATES.has(st.state.trim().toLowerCase())) {
+    return { installed: true, restarted: false, state: st.state };
+  }
   const mine = localVersion();
   const before = await checkHealth(cfg.port, healthHost(cfg.bind));
   if (before.ok && mine !== "unknown" && before.version === mine) {

--- a/bin/surface.ts
+++ b/bin/surface.ts
@@ -170,17 +170,18 @@ const COMMANDS: Record<string, CommandSpec> = {
   },
   skill: {
     help: [
-      "surface skill install [--to <skills-dir>]... [--copy|--link] [--json]",
+      "surface skill install [--to <skills-dir>]... [--copy|--link] [--force] [--json]",
       "  Canonical copy: <data-dir>/skills/surface/SKILL.md (the service's data dir), linked",
       "  (junction on Windows) into ~/.agents/skills/surface (open standard: Codex, Cursor,",
       "  Gemini CLI, Copilot, Zed, Amp, Goose, OpenCode, Roo, Kilo, Windsurf) and",
       "  ~/.claude/skills/surface (Claude Code). --to adds a harness-native skills dir",
       "  (e.g. ~/.cline/skills). --copy/--link set the mode for this run's targets (the --to",
       "  dirs, or the defaults when no --to is given); each target's mode is remembered and",
-      "  kept by later runs and surface upgrade. Idempotent; where symlinks are forbidden it",
-      "  copies instead.",
+      "  kept by later runs and surface upgrade. A locally edited canonical copy is kept",
+      "  (and mirrored to every target) until --force replaces it with the packaged skill.",
+      "  Idempotent; where symlinks are forbidden it copies instead.",
     ].join("\n"),
-    flags: { to: MULTI, copy: BOOL, link: BOOL, json: BOOL },
+    flags: { to: MULTI, copy: BOOL, link: BOOL, force: BOOL, json: BOOL },
     run: (ctx) => runSkill(ctx),
   },
   upgrade: {
@@ -227,7 +228,7 @@ interface ParsedArgs {
 const BOOLEAN_FLAGS = new Set([
   "help", "json", "no-ack", "no-open", "no-qr", "include-hidden",
   "freetext", "wait", "md", "toc", "autoplay", "loop", "user", "clear",
-  "copy", "link", "check",
+  "copy", "link", "check", "force",
 ]);
 
 // Flags that may repeat (--param a=1 --param b=2); collected in order.

--- a/bin/surface.ts
+++ b/bin/surface.ts
@@ -4,6 +4,7 @@ import path from "path";
 import { fileURLToPath } from "url";
 import { buildHostedPairingUrl, buildPairingUrl, renderTerminalQrCode } from "../server/startupAccess.js";
 import { runService, SERVICE_HELP } from "./service.js";
+import { runSkill, runUpgrade } from "./upgrade.js";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -71,6 +72,8 @@ Commands:
   clear-demos                Hide every surface tagged metadata.demo === true (seed-demos revives them)
   service <sub>              Manage the background service: install|uninstall|start|stop|
                              restart|status|health|logs (systemd / launchd / Scheduled Task)
+  skill install              Link SKILL.md into agent skill dirs (canonical copy in the data dir)
+  upgrade                    Update to the latest release, refresh the skill, restart the service
   version                    Print the installed Surface version (also: --version)
 
 Run "surface <command> --help" for command-specific options.
@@ -165,6 +168,30 @@ const COMMANDS: Record<string, CommandSpec> = {
     flags: { name: STR, port: NUM, "content-port": NUM, bind: STR, "data-dir": STR, timeout: NUM, json: BOOL, follow: BOOL, lines: NUM },
     run: (ctx) => runService(ctx),
   },
+  skill: {
+    help: [
+      "surface skill install [--to <skills-dir>]... [--copy] [--json]",
+      "  Canonical copy: <data-dir>/skills/surface/SKILL.md, linked (junction on Windows) into",
+      "  ~/.agents/skills/surface (open standard: Codex, Cursor, Gemini CLI, Copilot, Zed, Amp,",
+      "  Goose, OpenCode, Roo, Kilo, Windsurf) and ~/.claude/skills/surface (Claude Code).",
+      "  --to adds a harness-native skills dir (e.g. ~/.cline/skills); --copy writes copies",
+      "  instead of links for every target in the run. Idempotent; recorded targets are",
+      "  refreshed by surface upgrade.",
+    ].join("\n"),
+    flags: { to: MULTI, copy: BOOL, json: BOOL },
+    run: (ctx) => runSkill(ctx),
+  },
+  upgrade: {
+    help: [
+      "surface upgrade [--check] [--json] [--timeout <s>] [--name <service>]",
+      "  Everything at once: update surface-display to the latest npm release (global installs),",
+      "  refresh the canonical SKILL.md copy + all recorded skill links, and restart the service",
+      "  if it is running an older version (health-gated). --check reports without changing anything;",
+      "  --name targets a service installed under a non-default name.",
+    ].join("\n"),
+    flags: { check: BOOL, json: BOOL, timeout: NUM, name: STR },
+    run: (ctx) => runUpgrade(ctx),
+  },
   version: command("surface version"),
 };
 
@@ -197,10 +224,11 @@ interface ParsedArgs {
 const BOOLEAN_FLAGS = new Set([
   "help", "json", "no-ack", "no-open", "no-qr", "include-hidden",
   "freetext", "wait", "md", "toc", "autoplay", "loop", "user", "clear",
+  "copy", "check",
 ]);
 
 // Flags that may repeat (--param a=1 --param b=2); collected in order.
-const MULTI_FLAGS = new Set(["param"]);
+const MULTI_FLAGS = new Set(["param", "to"]);
 
 function parseArgs(argv: string[]): ParsedArgs {
   const positional: string[] = [];
@@ -397,11 +425,21 @@ async function call(method: string, pathname: string, body?: unknown): Promise<a
   const headers: Record<string, string> = {};
   if (body !== undefined) headers["Content-Type"] = "application/json";
   if (TOKEN) headers["Authorization"] = `Bearer ${TOKEN}`;
-  const res = await fetch(`${BASE}${pathname}`, {
-    method,
-    headers,
-    body: body !== undefined ? JSON.stringify(body) : undefined,
-  });
+  let res: Response;
+  try {
+    res = await fetch(`${BASE}${pathname}`, {
+      method,
+      headers,
+      body: body !== undefined ? JSON.stringify(body) : undefined,
+    });
+  } catch (e: any) {
+    const code = e?.cause?.code || e?.code;
+    throw new Error(
+      `Surface service unreachable at ${BASE}${code ? ` (${code})` : ""} — is it running? ` +
+      `Check: surface service health. Install/start: npm install -g surface-display && surface service install ` +
+      `(see INSTALL_FOR_AGENTS.md).`
+    );
+  }
   const text = await res.text();
   let parsed: any;
   try {

--- a/bin/surface.ts
+++ b/bin/surface.ts
@@ -170,15 +170,17 @@ const COMMANDS: Record<string, CommandSpec> = {
   },
   skill: {
     help: [
-      "surface skill install [--to <skills-dir>]... [--copy] [--json]",
-      "  Canonical copy: <data-dir>/skills/surface/SKILL.md, linked (junction on Windows) into",
-      "  ~/.agents/skills/surface (open standard: Codex, Cursor, Gemini CLI, Copilot, Zed, Amp,",
-      "  Goose, OpenCode, Roo, Kilo, Windsurf) and ~/.claude/skills/surface (Claude Code).",
-      "  --to adds a harness-native skills dir (e.g. ~/.cline/skills); --copy writes copies",
-      "  instead of links for every target in the run. Idempotent; recorded targets are",
-      "  refreshed by surface upgrade.",
+      "surface skill install [--to <skills-dir>]... [--copy|--link] [--json]",
+      "  Canonical copy: <data-dir>/skills/surface/SKILL.md (the service's data dir), linked",
+      "  (junction on Windows) into ~/.agents/skills/surface (open standard: Codex, Cursor,",
+      "  Gemini CLI, Copilot, Zed, Amp, Goose, OpenCode, Roo, Kilo, Windsurf) and",
+      "  ~/.claude/skills/surface (Claude Code). --to adds a harness-native skills dir",
+      "  (e.g. ~/.cline/skills). --copy/--link set the mode for this run's targets (the --to",
+      "  dirs, or the defaults when no --to is given); each target's mode is remembered and",
+      "  kept by later runs and surface upgrade. Idempotent; where symlinks are forbidden it",
+      "  copies instead.",
     ].join("\n"),
-    flags: { to: MULTI, copy: BOOL, json: BOOL },
+    flags: { to: MULTI, copy: BOOL, link: BOOL, json: BOOL },
     run: (ctx) => runSkill(ctx),
   },
   upgrade: {
@@ -186,8 +188,9 @@ const COMMANDS: Record<string, CommandSpec> = {
       "surface upgrade [--check] [--json] [--timeout <s>] [--name <service>]",
       "  Everything at once: update surface-display to the latest npm release (global installs),",
       "  refresh the canonical SKILL.md copy + all recorded skill links, and restart the service",
-      "  if it is running an older version (health-gated). --check reports without changing anything;",
-      "  --name targets a service installed under a non-default name.",
+      "  if it is running an older version (health-gated; a cleanly stopped service is left",
+      "  stopped). --check reports without changing anything; --name targets a service installed",
+      "  under a non-default name.",
     ].join("\n"),
     flags: { check: BOOL, json: BOOL, timeout: NUM, name: STR },
     run: (ctx) => runUpgrade(ctx),
@@ -224,7 +227,7 @@ interface ParsedArgs {
 const BOOLEAN_FLAGS = new Set([
   "help", "json", "no-ack", "no-open", "no-qr", "include-hidden",
   "freetext", "wait", "md", "toc", "autoplay", "loop", "user", "clear",
-  "copy", "check",
+  "copy", "link", "check",
 ]);
 
 // Flags that may repeat (--param a=1 --param b=2); collected in order.

--- a/bin/upgrade.ts
+++ b/bin/upgrade.ts
@@ -6,6 +6,7 @@
 // refreshes the canonical copy from the installed package, so the skill text
 // every harness reads is always the one matching the installed binary.
 import { spawnSync } from "child_process";
+import { createHash } from "crypto";
 import fs from "fs";
 import os from "os";
 import path from "path";
@@ -70,10 +71,21 @@ interface SkillReport {
   canonical: string;
   version: string;
   updated: boolean;
+  edited: boolean;
   links: LinkResult[];
 }
 
-function syncCanonical(base: string): { canonical: string; updated: boolean } {
+function sha256(buf: Buffer): string {
+  return createHash("sha256").update(buf).digest("hex");
+}
+
+// Three canonical states, told apart by the hash of what WE last wrote
+// (skill_sha256 in install-state): matches the package → fresh; matches the
+// recorded hash → our stale copy, safe to overwrite; matches neither → the
+// user edited it — keep it (links and copies then mirror the edit) until
+// `surface skill install --force`. No recorded hash + mismatch counts as
+// edited: unknown provenance is not ours to destroy.
+function syncCanonical(base: string, force: boolean, recordedSha: string | null): { canonical: string; updated: boolean; edited: boolean } {
   const src = packageSkillPath();
   if (!fs.existsSync(src)) {
     throw new Error(`SKILL.md not found at ${src} (broken install?)`);
@@ -82,10 +94,13 @@ function syncCanonical(base: string): { canonical: string; updated: boolean } {
   const dest = path.join(dir, "SKILL.md");
   const next = fs.readFileSync(src);
   const prev = fs.existsSync(dest) ? fs.readFileSync(dest) : null;
-  if (prev && prev.equals(next)) return { canonical: dest, updated: false };
+  if (prev && prev.equals(next)) return { canonical: dest, updated: false, edited: false };
+  if (prev && !force && sha256(prev) !== recordedSha) {
+    return { canonical: dest, updated: false, edited: true };
+  }
   fs.mkdirSync(dir, { recursive: true });
   fs.writeFileSync(dest, next);
-  return { canonical: dest, updated: prev !== null };
+  return { canonical: dest, updated: prev !== null, edited: false };
 }
 
 function linksTo(target: string, canonical: string): boolean {
@@ -96,7 +111,9 @@ function linksTo(target: string, canonical: string): boolean {
   }
 }
 
-function copyInto(target: string): void {
+// Managed copies mirror the CANONICAL file, not the package — so a kept
+// user edit propagates to copy targets exactly like it does through links.
+function copyInto(target: string, canonicalDir: string): void {
   fs.mkdirSync(target, { recursive: true });
   const dest = path.join(target, "SKILL.md");
   try {
@@ -105,7 +122,7 @@ function copyInto(target: string): void {
   } catch {
     // dest missing — nothing to replace
   }
-  fs.copyFileSync(packageSkillPath(), dest);
+  fs.copyFileSync(path.join(canonicalDir, "SKILL.md"), dest);
 }
 
 // A directory holding only a SKILL.md is adopted only when that file is a
@@ -147,7 +164,7 @@ function ensureTarget(skillsDir: string, canonicalDir: string, copy: boolean, ow
       return { path: target, mode: "skipped", note: "its SKILL.md is not a Surface skill — not managed by surface" };
     }
     if (copy) {
-      copyInto(target);
+      copyInto(target, canonicalDir);
       return { path: target, mode: "copied" };
     }
     fs.rmSync(target, { recursive: true, force: true });
@@ -158,7 +175,7 @@ function ensureTarget(skillsDir: string, canonicalDir: string, copy: boolean, ow
 
   fs.mkdirSync(skillsDir, { recursive: true });
   if (copy) {
-    copyInto(target);
+    copyInto(target, canonicalDir);
     return { path: target, mode: "copied" };
   }
   try {
@@ -167,7 +184,7 @@ function ensureTarget(skillsDir: string, canonicalDir: string, copy: boolean, ow
   } catch (e: any) {
     // Symlinks can be forbidden (e.g. Windows without developer mode) —
     // fall back to a managed copy; upgrade rewrites it from install-state.
-    copyInto(target);
+    copyInto(target, canonicalDir);
     return { path: target, mode: "copied", note: `symlink failed (${e?.code || e}), copied instead` };
   }
 }
@@ -185,6 +202,7 @@ function readInstallState(base: string): Record<string, unknown> | null {
     if (e?.code === "ENOENT") return {
       service: "pending",
       skill_saved_to: null,
+      skill_sha256: null,
       tutorial: "pending",
       surface_version: null,
       installed_at: null,
@@ -194,10 +212,19 @@ function readInstallState(base: string): Record<string, unknown> | null {
   }
 }
 
-function recordSkillState(report: SkillReport, base: string, prev: Map<string, "copy" | "link">): void {
+function recordedSkillSha(base: string): string | null {
+  const sha = (readInstallState(base) as any)?.skill_sha256;
+  return typeof sha === "string" ? sha : null;
+}
+
+function recordSkillState(report: SkillReport, base: string, prev: Map<string, "copy" | "link">, writtenSha: string | null): void {
   const state = readInstallState(base);
   if (!state) return;
   state.skill_saved_to = report.canonical;
+  // Only stamp the hash when the canonical holds OUR content; a kept edit
+  // must keep the old hash, or the next run would mistake the edit for a
+  // stale copy and clobber it.
+  if (writtenSha) state.skill_sha256 = writtenSha;
   const links = report.links
     .filter((l) => l.mode !== "skipped" && l.mode !== "failed")
     .map((l) => ({ path: l.path, mode: l.mode === "copied" ? "copy" : "link" }));
@@ -225,9 +252,9 @@ function recordedLinks(base: string): { path: string; mode: string }[] {
 // given, else the default targets. Every other recorded target keeps its
 // recorded mode; new targets default to link. Modes are remembered per
 // target, so `surface upgrade` refreshes without reshaping anything.
-export function syncSkill(extraTo: string[], copy: boolean, link = false, name?: string): SkillReport {
+export function syncSkill(extraTo: string[], copy: boolean, link = false, name?: string, force = false): SkillReport {
   const base = dataDir(name);
-  const { canonical, updated } = syncCanonical(base);
+  const { canonical, updated, edited } = syncCanonical(base, force, recordedSkillSha(base));
   const canonicalDir = path.dirname(canonical);
   const recorded = new Map<string, "copy" | "link">();
   for (const l of recordedLinks(base)) recorded.set(path.resolve(l.path), l.mode === "copy" ? "copy" : "link");
@@ -261,17 +288,20 @@ export function syncSkill(extraTo: string[], copy: boolean, link = false, name?:
       links.push({ path: target, mode: "failed", note: String(e?.code || e?.message || e) });
     }
   }
-  const report: SkillReport = { canonical, version: localVersion(), updated, links };
-  recordSkillState(report, base, recorded);
+  const report: SkillReport = { canonical, version: localVersion(), updated, edited, links };
+  recordSkillState(report, base, recorded, edited ? null : sha256(fs.readFileSync(packageSkillPath())));
   return report;
 }
 
-export function skillFresh(name?: string): { canonical: string; fresh: boolean } {
-  const dest = path.join(canonicalSkillDir(dataDir(name)), "SKILL.md");
+export function skillFresh(name?: string): { canonical: string; fresh: boolean; edited: boolean } {
+  const base = dataDir(name);
+  const dest = path.join(canonicalSkillDir(base), "SKILL.md");
   try {
-    return { canonical: dest, fresh: fs.readFileSync(dest).equals(fs.readFileSync(packageSkillPath())) };
+    const cur = fs.readFileSync(dest);
+    if (cur.equals(fs.readFileSync(packageSkillPath()))) return { canonical: dest, fresh: true, edited: false };
+    return { canonical: dest, fresh: false, edited: sha256(cur) !== recordedSkillSha(base) };
   } catch {
-    return { canonical: dest, fresh: false };
+    return { canonical: dest, fresh: false, edited: false };
   }
 }
 
@@ -279,25 +309,30 @@ export function skillFresh(name?: string): { canonical: string; fresh: boolean }
 
 export async function runSkill({ positional, flags, multi }: Ctx): Promise<void> {
   if (positional[0] !== "install") {
-    console.error("usage: surface skill install [--to <skills-dir>]... [--copy|--link] [--json]");
+    console.error("usage: surface skill install [--to <skills-dir>]... [--copy|--link] [--force] [--json]");
     process.exit(2);
   }
   if (flags.copy === true && flags.link === true) {
     console.error("--copy and --link are mutually exclusive");
     process.exit(2);
   }
-  const report = syncSkill(multi.to || [], flags.copy === true, flags.link === true);
+  const report = syncSkill(multi.to || [], flags.copy === true, flags.link === true, undefined, flags.force === true);
   const failed = report.links.filter((l) => l.mode === "failed");
   if (flags.json === true) {
     console.log(JSON.stringify(report, null, 2));
   } else {
-    console.log(`skill ${report.version} → ${report.canonical}${report.updated ? " (updated)" : ""}`);
+    console.log(`skill ${report.version} → ${report.canonical}${skillSuffix(report)}`);
     for (const l of report.links) {
       console.log(`  ${l.mode.padEnd(7)} ${l.path}${l.note ? `  (${l.note})` : ""}`);
     }
     if (failed.length) console.error(`${failed.length} target(s) could not be written — see notes above`);
   }
   if (failed.length) process.exit(1);
+}
+
+function skillSuffix(report: SkillReport): string {
+  if (report.edited) return " (locally edited — kept; surface skill install --force to replace)";
+  return report.updated ? " (updated)" : "";
 }
 
 // ── surface upgrade ──
@@ -372,7 +407,8 @@ export async function runUpgrade({ flags }: Ctx): Promise<void> {
     if (json) console.log(JSON.stringify(report, null, 2));
     else {
       console.log(available ? `update available: ${current} → ${latest}` : `up to date (${current})`);
-      if (!skill.fresh) console.log(`skill copy stale/missing at ${skill.canonical} — run: surface upgrade`);
+      if (skill.edited) console.log(`skill copy locally edited at ${skill.canonical} — kept (surface skill install --force to replace)`);
+      else if (!skill.fresh) console.log(`skill copy stale/missing at ${skill.canonical} — run: surface upgrade`);
       if (available && context !== "global") console.log(contextAdvice(context));
     }
     return;
@@ -410,7 +446,7 @@ export async function runUpgrade({ flags }: Ctx): Promise<void> {
   }
   console.log(available && packageStep.startsWith("updated") ? packageStep : `package: ${packageStep === "unchanged" ? `up to date (${current})` : packageStep}`);
   if (available && context !== "global") console.log(contextAdvice(context));
-  console.log(`skill  : ${skill.version} → ${skill.canonical}${skill.updated ? " (updated)" : ""}`);
+  console.log(`skill  : ${skill.version} → ${skill.canonical}${skillSuffix(skill)}`);
   for (const l of skill.links) console.log(`  ${l.mode.padEnd(7)} ${l.path}${l.note ? `  (${l.note})` : ""}`);
   if (!service.installed) console.log("service: not installed here — skipped");
   else if (service.restarted && service.error) {

--- a/bin/upgrade.ts
+++ b/bin/upgrade.ts
@@ -10,7 +10,7 @@ import fs from "fs";
 import os from "os";
 import path from "path";
 import { fileURLToPath } from "url";
-import { localVersion, restartServiceIfStale } from "./service.js";
+import { localVersion, restartServiceIfStale, savedServiceDataDir } from "./service.js";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -32,7 +32,12 @@ function packageSkillPath(): string {
   return path.join(packageRoot(), "SKILL.md");
 }
 
-export function dataDir(): string {
+export function dataDir(name = "surface"): string {
+  // Mirror resolveConfig in service.ts: the service's saved data dir wins,
+  // then SURFACE_DATA_DIR, then ~/.surface — so the canonical skill copy and
+  // install-state.json live where `surface service health` looks for them.
+  const saved = savedServiceDataDir(name);
+  if (saved) return saved;
   return process.env.SURFACE_DATA_DIR
     ? path.resolve(process.env.SURFACE_DATA_DIR)
     : path.join(os.homedir(), ".surface");
@@ -57,7 +62,7 @@ function defaultTargets(): string[] {
 
 interface LinkResult {
   path: string;
-  mode: "linked" | "copied" | "kept" | "skipped";
+  mode: "linked" | "copied" | "kept" | "skipped" | "failed";
   note?: string;
 }
 
@@ -68,12 +73,12 @@ interface SkillReport {
   links: LinkResult[];
 }
 
-function syncCanonical(): { canonical: string; updated: boolean } {
+function syncCanonical(base: string): { canonical: string; updated: boolean } {
   const src = packageSkillPath();
   if (!fs.existsSync(src)) {
     throw new Error(`SKILL.md not found at ${src} (broken install?)`);
   }
-  const dir = canonicalSkillDir();
+  const dir = canonicalSkillDir(base);
   const dest = path.join(dir, "SKILL.md");
   const next = fs.readFileSync(src);
   const prev = fs.existsSync(dest) ? fs.readFileSync(dest) : null;
@@ -93,13 +98,33 @@ function linksTo(target: string, canonical: string): boolean {
 
 function copyInto(target: string): void {
   fs.mkdirSync(target, { recursive: true });
-  fs.copyFileSync(packageSkillPath(), path.join(target, "SKILL.md"));
+  const dest = path.join(target, "SKILL.md");
+  try {
+    // never write through a planted symlink — replace it
+    if (fs.lstatSync(dest).isSymbolicLink()) fs.unlinkSync(dest);
+  } catch {
+    // dest missing — nothing to replace
+  }
+  fs.copyFileSync(packageSkillPath(), dest);
+}
+
+// A directory holding only a SKILL.md is adopted only when that file is a
+// Surface skill (legacy manual copies from older install instructions);
+// someone's unrelated single-file skill is left alone.
+function looksLikeSurfaceSkill(file: string): boolean {
+  try {
+    return /^\s*name:\s*surface\s*$/m.test(fs.readFileSync(file, "utf8").slice(0, 2048));
+  } catch {
+    return false;
+  }
 }
 
 // Ensure <skillsDir>/surface is a link to the canonical dir (or a managed
-// copy). Refuses to replace a directory holding anything besides SKILL.md —
-// that is someone else's skill.
-function ensureTarget(skillsDir: string, canonicalDir: string, copy: boolean): LinkResult {
+// copy). Refuses to replace a directory holding anything besides a Surface
+// SKILL.md — that is someone else's skill. `owned` = recorded in
+// install-state as ours, which skips the content check (a stale managed copy
+// may hold old text).
+function ensureTarget(skillsDir: string, canonicalDir: string, copy: boolean, owned: boolean): LinkResult {
   const target = path.join(skillsDir, "surface");
   let st: fs.Stats | null = null;
   try {
@@ -116,6 +141,10 @@ function ensureTarget(skillsDir: string, canonicalDir: string, copy: boolean): L
     const entries = fs.readdirSync(target).filter((e) => e !== "SKILL.md");
     if (entries.length > 0) {
       return { path: target, mode: "skipped", note: `contains other files (${entries[0]}…) — not managed by surface` };
+    }
+    const skillFile = path.join(target, "SKILL.md");
+    if (!owned && fs.existsSync(skillFile) && !looksLikeSurfaceSkill(skillFile)) {
+      return { path: target, mode: "skipped", note: "its SKILL.md is not a Surface skill — not managed by surface" };
     }
     if (copy) {
       copyInto(target);
@@ -145,13 +174,13 @@ function ensureTarget(skillsDir: string, canonicalDir: string, copy: boolean): L
 
 // ── install-state.json (the agent bootstrap contract in INSTALL_FOR_AGENTS.md) ──
 
-function installStatePath(): string {
-  return path.join(dataDir(), "install-state.json");
+function installStatePath(base: string): string {
+  return path.join(base, "install-state.json");
 }
 
-function readInstallState(): Record<string, unknown> | null {
+function readInstallState(base: string): Record<string, unknown> | null {
   try {
-    return JSON.parse(fs.readFileSync(installStatePath(), "utf8"));
+    return JSON.parse(fs.readFileSync(installStatePath(base), "utf8"));
   } catch (e: any) {
     if (e?.code === "ENOENT") return {
       service: "pending",
@@ -165,47 +194,80 @@ function readInstallState(): Record<string, unknown> | null {
   }
 }
 
-function recordSkillState(report: SkillReport): void {
-  const state = readInstallState();
+function recordSkillState(report: SkillReport, base: string, prev: Map<string, "copy" | "link">): void {
+  const state = readInstallState(base);
   if (!state) return;
   state.skill_saved_to = report.canonical;
-  state.skill_links = report.links
-    .filter((l) => l.mode !== "skipped")
+  const links = report.links
+    .filter((l) => l.mode !== "skipped" && l.mode !== "failed")
     .map((l) => ({ path: l.path, mode: l.mode === "copied" ? "copy" : "link" }));
-  fs.mkdirSync(dataDir(), { recursive: true });
-  fs.writeFileSync(installStatePath(), JSON.stringify(state, null, 2) + "\n");
+  for (const l of report.links) {
+    // a failed target stays recorded with its old mode so the next run retries it
+    if (l.mode === "failed" && prev.has(path.resolve(l.path))) {
+      links.push({ path: l.path, mode: prev.get(path.resolve(l.path))! });
+    }
+  }
+  state.skill_links = links;
+  fs.mkdirSync(base, { recursive: true });
+  const file = installStatePath(base);
+  const tmp = `${file}.tmp-${process.pid}`;
+  fs.writeFileSync(tmp, JSON.stringify(state, null, 2) + "\n");
+  fs.renameSync(tmp, file); // atomic: a concurrent reader never sees a partial write
 }
 
-function recordedLinks(): { path: string; mode: string }[] {
-  const state = readInstallState();
+function recordedLinks(base: string): { path: string; mode: string }[] {
+  const state = readInstallState(base);
   const links = (state as any)?.skill_links;
   return Array.isArray(links) ? links.filter((l) => typeof l?.path === "string") : [];
 }
 
-export function syncSkill(extraTo: string[], copy: boolean): SkillReport {
-  const { canonical, updated } = syncCanonical();
+// Mode rules: --copy/--link apply to this run's scope — the --to dirs when
+// given, else the default targets. Every other recorded target keeps its
+// recorded mode; new targets default to link. Modes are remembered per
+// target, so `surface upgrade` refreshes without reshaping anything.
+export function syncSkill(extraTo: string[], copy: boolean, link = false, name?: string): SkillReport {
+  const base = dataDir(name);
+  const { canonical, updated } = syncCanonical(base);
   const canonicalDir = path.dirname(canonical);
-  // Union: defaults + explicit --to + everything recorded by earlier installs
-  // (so copies made where symlinks failed keep getting refreshed).
+  const recorded = new Map<string, "copy" | "link">();
+  for (const l of recordedLinks(base)) recorded.set(path.resolve(l.path), l.mode === "copy" ? "copy" : "link");
+  const recCopy = (skillsDir: string) => recorded.get(path.join(skillsDir, "surface")) === "copy";
+  const modeFor = (skillsDir: string, inScope: boolean) =>
+    inScope && copy ? true : inScope && link ? false : recCopy(skillsDir);
+
   const targets = new Map<string, boolean>(); // skillsDir -> copy?
-  for (const dir of defaultTargets()) targets.set(path.resolve(dir), copy);
-  for (const dir of extraTo) targets.set(path.resolve(dir), copy);
-  for (const l of recordedLinks()) {
-    const skillsDir = path.dirname(path.resolve(l.path));
-    if (!targets.has(skillsDir)) targets.set(skillsDir, l.mode === "copy");
+  const explicit = extraTo.length > 0;
+  for (const dir of defaultTargets()) {
+    const d = path.resolve(dir);
+    targets.set(d, modeFor(d, !explicit));
   }
+  for (const dir of extraTo) {
+    const d = path.resolve(dir);
+    targets.set(d, modeFor(d, true));
+  }
+  for (const [t] of recorded) {
+    const skillsDir = path.dirname(t);
+    if (!targets.has(skillsDir)) targets.set(skillsDir, recCopy(skillsDir));
+  }
+
   const links: LinkResult[] = [];
   for (const [skillsDir, asCopy] of targets) {
-    if (path.resolve(path.join(skillsDir, "surface")) === path.resolve(canonicalDir)) continue;
-    links.push(ensureTarget(skillsDir, canonicalDir, asCopy));
+    const target = path.join(skillsDir, "surface");
+    if (path.resolve(target) === path.resolve(canonicalDir)) continue;
+    try {
+      links.push(ensureTarget(skillsDir, canonicalDir, asCopy, recorded.has(path.resolve(target))));
+    } catch (e: any) {
+      // one unwritable target must not abort the converger — report and move on
+      links.push({ path: target, mode: "failed", note: String(e?.code || e?.message || e) });
+    }
   }
   const report: SkillReport = { canonical, version: localVersion(), updated, links };
-  recordSkillState(report);
+  recordSkillState(report, base, recorded);
   return report;
 }
 
-export function skillFresh(): { canonical: string; fresh: boolean } {
-  const dest = path.join(canonicalSkillDir(), "SKILL.md");
+export function skillFresh(name?: string): { canonical: string; fresh: boolean } {
+  const dest = path.join(canonicalSkillDir(dataDir(name)), "SKILL.md");
   try {
     return { canonical: dest, fresh: fs.readFileSync(dest).equals(fs.readFileSync(packageSkillPath())) };
   } catch {
@@ -217,18 +279,25 @@ export function skillFresh(): { canonical: string; fresh: boolean } {
 
 export async function runSkill({ positional, flags, multi }: Ctx): Promise<void> {
   if (positional[0] !== "install") {
-    console.error("usage: surface skill install [--to <skills-dir>]... [--copy] [--json]");
+    console.error("usage: surface skill install [--to <skills-dir>]... [--copy|--link] [--json]");
     process.exit(2);
   }
-  const report = syncSkill(multi.to || [], flags.copy === true);
+  if (flags.copy === true && flags.link === true) {
+    console.error("--copy and --link are mutually exclusive");
+    process.exit(2);
+  }
+  const report = syncSkill(multi.to || [], flags.copy === true, flags.link === true);
+  const failed = report.links.filter((l) => l.mode === "failed");
   if (flags.json === true) {
     console.log(JSON.stringify(report, null, 2));
-    return;
+  } else {
+    console.log(`skill ${report.version} → ${report.canonical}${report.updated ? " (updated)" : ""}`);
+    for (const l of report.links) {
+      console.log(`  ${l.mode.padEnd(7)} ${l.path}${l.note ? `  (${l.note})` : ""}`);
+    }
+    if (failed.length) console.error(`${failed.length} target(s) could not be written — see notes above`);
   }
-  console.log(`skill ${report.version} → ${report.canonical}${report.updated ? " (updated)" : ""}`);
-  for (const l of report.links) {
-    console.log(`  ${l.mode.padEnd(7)} ${l.path}${l.note ? `  (${l.note})` : ""}`);
-  }
+  if (failed.length) process.exit(1);
 }
 
 // ── surface upgrade ──
@@ -236,6 +305,8 @@ export async function runSkill({ positional, flags, multi }: Ctx): Promise<void>
 function registryUrl(): string {
   return (process.env.SURFACE_NPM_REGISTRY || "https://registry.npmjs.org").replace(/\/$/, "");
 }
+
+const SEMVER = /^\d+\.\d+\.\d+(?:-[0-9A-Za-z][0-9A-Za-z.-]*)?(?:\+[0-9A-Za-z][0-9A-Za-z.-]*)?$/;
 
 async function latestVersion(): Promise<string> {
   const url = `${registryUrl()}/surface-display/latest`;
@@ -247,7 +318,10 @@ async function latestVersion(): Promise<string> {
   }
   if (!res.ok) throw new Error(`registry answered ${res.status} for ${url}`);
   const body: any = await res.json();
-  if (typeof body?.version !== "string") throw new Error(`no version in registry response from ${url}`);
+  // strict gate: this string reaches a shell-backed npm spawn on Windows
+  if (typeof body?.version !== "string" || !SEMVER.test(body.version)) {
+    throw new Error(`registry returned an invalid version (${JSON.stringify(body?.version).slice(0, 60)}) from ${url}`);
+  }
   return body.version;
 }
 
@@ -273,7 +347,10 @@ function installContext(): InstallContext {
   });
   const globalRoot = probe.status === 0 ? probe.stdout.trim() : "";
   try {
-    if (globalRoot && root.startsWith(fs.realpathSync(globalRoot))) return "global";
+    if (globalRoot) {
+      const rel = path.relative(fs.realpathSync(globalRoot), root);
+      if (rel === "" || (!rel.startsWith("..") && !path.isAbsolute(rel))) return "global";
+    }
   } catch {
     // global root missing — treat as local
   }
@@ -283,13 +360,14 @@ function installContext(): InstallContext {
 export async function runUpgrade({ flags }: Ctx): Promise<void> {
   const json = flags.json === true;
   const timeoutSec = typeof flags.timeout === "string" ? Number(flags.timeout) : 30;
+  const name = typeof flags.name === "string" ? flags.name : undefined;
   const current = localVersion();
   const latest = await latestVersion();
   const available = newerThan(latest, current);
   const context = installContext();
 
   if (flags.check === true) {
-    const skill = skillFresh();
+    const skill = skillFresh(name);
     const report = { current, latest, update_available: available, context, skill };
     if (json) console.log(JSON.stringify(report, null, 2));
     else {
@@ -320,12 +398,14 @@ export async function runUpgrade({ flags }: Ctx): Promise<void> {
 
   // Always converge skill + service, even when already on the latest version —
   // this is what finishes a manual `npm update -g` someone ran without us.
-  const skill = syncSkill([], false);
-  const service = await restartServiceIfStale(timeoutSec, typeof flags.name === "string" ? flags.name : undefined);
+  const skill = syncSkill([], false, false, name);
+  const service = await restartServiceIfStale(timeoutSec, name);
+  const failedLinks = skill.links.filter((l) => l.mode === "failed");
 
   const report = { previous: current, installed, latest, package: packageStep, context, skill, service };
   if (json) {
     console.log(JSON.stringify(report, null, 2));
+    if ((service.restarted && service.error) || failedLinks.length) process.exit(1);
     return;
   }
   console.log(available && packageStep.startsWith("updated") ? packageStep : `package: ${packageStep === "unchanged" ? `up to date (${current})` : packageStep}`);
@@ -333,11 +413,16 @@ export async function runUpgrade({ flags }: Ctx): Promise<void> {
   console.log(`skill  : ${skill.version} → ${skill.canonical}${skill.updated ? " (updated)" : ""}`);
   for (const l of skill.links) console.log(`  ${l.mode.padEnd(7)} ${l.path}${l.note ? `  (${l.note})` : ""}`);
   if (!service.installed) console.log("service: not installed here — skipped");
-  else if (!service.restarted) console.log(`service: already on ${service.version} — no restart needed`);
-  else if (service.error) {
+  else if (service.restarted && service.error) {
     console.error(`service: restarted but not healthy — ${service.error}`);
     process.exit(1);
-  } else console.log(`service: restarted, now ${service.version}`);
+  } else if (service.restarted) console.log(`service: restarted, now ${service.version}`);
+  else if (service.version) console.log(`service: already on ${service.version} — no restart needed`);
+  else console.log(`service: ${service.state || "stopped"} — left as-is (start it with: surface service start)`);
+  if (failedLinks.length) {
+    console.error(`skill  : ${failedLinks.length} target(s) could not be written — see notes above`);
+    process.exit(1);
+  }
 }
 
 function contextAdvice(context: InstallContext): string {

--- a/bin/upgrade.ts
+++ b/bin/upgrade.ts
@@ -152,6 +152,12 @@ function ensureTarget(skillsDir: string, canonicalDir: string, copy: boolean, ow
 
   if (st?.isSymbolicLink()) {
     if (!copy && linksTo(target, canonicalDir)) return { path: target, mode: "kept" };
+    // An unrecorded symlink may be the user's own arrangement (e.g. pointing
+    // at their custom skill fork) — only repair links that are ours or that
+    // resolve to a Surface skill.
+    if (!owned && !linksTo(target, canonicalDir) && !looksLikeSurfaceSkill(path.join(target, "SKILL.md"))) {
+      return { path: target, mode: "skipped", note: "symlink does not point at a Surface skill — not managed by surface" };
+    }
     fs.unlinkSync(target); // rmSync throws EISDIR on a symlink-to-directory
     st = null;
   } else if (st?.isDirectory()) {
@@ -418,10 +424,14 @@ export async function runUpgrade({ flags }: Ctx): Promise<void> {
   let packageStep = "unchanged";
   if (available && context === "global") {
     const res = spawnSync(npmCmd(), ["install", "-g", `surface-display@${latest}`], {
-      stdio: "inherit",
+      // --json promises pure JSON on stdout — npm's install chatter goes to
+      // stderr there instead of corrupting the report.
+      stdio: json ? ["ignore", "pipe", "inherit"] : "inherit",
+      encoding: "utf8",
       shell: process.platform === "win32",
     });
     if (res.status !== 0) {
+      if (json && res.stdout) process.stderr.write(res.stdout);
       console.error(`npm install -g surface-display@${latest} failed (exit ${res.status ?? "?"})`);
       process.exit(1);
     }

--- a/bin/upgrade.ts
+++ b/bin/upgrade.ts
@@ -1,0 +1,347 @@
+// surface skill install / surface upgrade — the self-maintenance pair.
+//
+// The skill model: one canonical copy of SKILL.md lives in the data dir
+// (<data-dir>/skills/surface/SKILL.md) and every agent harness gets a
+// directory link (junction on Windows) pointing at it. `surface upgrade`
+// refreshes the canonical copy from the installed package, so the skill text
+// every harness reads is always the one matching the installed binary.
+import { spawnSync } from "child_process";
+import fs from "fs";
+import os from "os";
+import path from "path";
+import { fileURLToPath } from "url";
+import { localVersion, restartServiceIfStale } from "./service.js";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+interface Ctx {
+  positional: string[];
+  flags: Record<string, string | boolean>;
+  multi: Record<string, string[]>;
+}
+
+// ── paths ──
+
+export function packageRoot(): string {
+  // dist/surface.mjs in the installed package, bin/upgrade.ts in a clone —
+  // SKILL.md and package.json sit next to the parent either way.
+  return fs.realpathSync(path.join(__dirname, ".."));
+}
+
+function packageSkillPath(): string {
+  return path.join(packageRoot(), "SKILL.md");
+}
+
+export function dataDir(): string {
+  return process.env.SURFACE_DATA_DIR
+    ? path.resolve(process.env.SURFACE_DATA_DIR)
+    : path.join(os.homedir(), ".surface");
+}
+
+export function canonicalSkillDir(base = dataDir()): string {
+  return path.join(base, "skills", "surface");
+}
+
+function defaultTargets(): string[] {
+  // Two links cover the ecosystem: ~/.agents/skills is the open standard
+  // (agentskills.io — Codex, Cursor, Gemini CLI, Copilot, Zed, Amp, Goose,
+  // OpenCode, Roo, Kilo, Windsurf); ~/.claude/skills is Claude Code, which
+  // does not read ~/.agents/. Harness-native dirs go through --to.
+  return [
+    path.join(os.homedir(), ".agents", "skills"),
+    path.join(os.homedir(), ".claude", "skills"),
+  ];
+}
+
+// ── skill sync ──
+
+interface LinkResult {
+  path: string;
+  mode: "linked" | "copied" | "kept" | "skipped";
+  note?: string;
+}
+
+interface SkillReport {
+  canonical: string;
+  version: string;
+  updated: boolean;
+  links: LinkResult[];
+}
+
+function syncCanonical(): { canonical: string; updated: boolean } {
+  const src = packageSkillPath();
+  if (!fs.existsSync(src)) {
+    throw new Error(`SKILL.md not found at ${src} (broken install?)`);
+  }
+  const dir = canonicalSkillDir();
+  const dest = path.join(dir, "SKILL.md");
+  const next = fs.readFileSync(src);
+  const prev = fs.existsSync(dest) ? fs.readFileSync(dest) : null;
+  if (prev && prev.equals(next)) return { canonical: dest, updated: false };
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(dest, next);
+  return { canonical: dest, updated: prev !== null };
+}
+
+function linksTo(target: string, canonical: string): boolean {
+  try {
+    return fs.realpathSync(target) === fs.realpathSync(canonical);
+  } catch {
+    return false;
+  }
+}
+
+function copyInto(target: string): void {
+  fs.mkdirSync(target, { recursive: true });
+  fs.copyFileSync(packageSkillPath(), path.join(target, "SKILL.md"));
+}
+
+// Ensure <skillsDir>/surface is a link to the canonical dir (or a managed
+// copy). Refuses to replace a directory holding anything besides SKILL.md —
+// that is someone else's skill.
+function ensureTarget(skillsDir: string, canonicalDir: string, copy: boolean): LinkResult {
+  const target = path.join(skillsDir, "surface");
+  let st: fs.Stats | null = null;
+  try {
+    st = fs.lstatSync(target);
+  } catch {
+    st = null;
+  }
+
+  if (st?.isSymbolicLink()) {
+    if (!copy && linksTo(target, canonicalDir)) return { path: target, mode: "kept" };
+    fs.unlinkSync(target); // rmSync throws EISDIR on a symlink-to-directory
+    st = null;
+  } else if (st?.isDirectory()) {
+    const entries = fs.readdirSync(target).filter((e) => e !== "SKILL.md");
+    if (entries.length > 0) {
+      return { path: target, mode: "skipped", note: `contains other files (${entries[0]}…) — not managed by surface` };
+    }
+    if (copy) {
+      copyInto(target);
+      return { path: target, mode: "copied" };
+    }
+    fs.rmSync(target, { recursive: true, force: true });
+    st = null;
+  } else if (st) {
+    return { path: target, mode: "skipped", note: "exists and is not a directory or symlink" };
+  }
+
+  fs.mkdirSync(skillsDir, { recursive: true });
+  if (copy) {
+    copyInto(target);
+    return { path: target, mode: "copied" };
+  }
+  try {
+    fs.symlinkSync(canonicalDir, target, process.platform === "win32" ? "junction" : "dir");
+    return { path: target, mode: "linked" };
+  } catch (e: any) {
+    // Symlinks can be forbidden (e.g. Windows without developer mode) —
+    // fall back to a managed copy; upgrade rewrites it from install-state.
+    copyInto(target);
+    return { path: target, mode: "copied", note: `symlink failed (${e?.code || e}), copied instead` };
+  }
+}
+
+// ── install-state.json (the agent bootstrap contract in INSTALL_FOR_AGENTS.md) ──
+
+function installStatePath(): string {
+  return path.join(dataDir(), "install-state.json");
+}
+
+function readInstallState(): Record<string, unknown> | null {
+  try {
+    return JSON.parse(fs.readFileSync(installStatePath(), "utf8"));
+  } catch (e: any) {
+    if (e?.code === "ENOENT") return {
+      service: "pending",
+      skill_saved_to: null,
+      tutorial: "pending",
+      surface_version: null,
+      installed_at: null,
+      notes: null,
+    };
+    return null; // corrupt — leave it alone
+  }
+}
+
+function recordSkillState(report: SkillReport): void {
+  const state = readInstallState();
+  if (!state) return;
+  state.skill_saved_to = report.canonical;
+  state.skill_links = report.links
+    .filter((l) => l.mode !== "skipped")
+    .map((l) => ({ path: l.path, mode: l.mode === "copied" ? "copy" : "link" }));
+  fs.mkdirSync(dataDir(), { recursive: true });
+  fs.writeFileSync(installStatePath(), JSON.stringify(state, null, 2) + "\n");
+}
+
+function recordedLinks(): { path: string; mode: string }[] {
+  const state = readInstallState();
+  const links = (state as any)?.skill_links;
+  return Array.isArray(links) ? links.filter((l) => typeof l?.path === "string") : [];
+}
+
+export function syncSkill(extraTo: string[], copy: boolean): SkillReport {
+  const { canonical, updated } = syncCanonical();
+  const canonicalDir = path.dirname(canonical);
+  // Union: defaults + explicit --to + everything recorded by earlier installs
+  // (so copies made where symlinks failed keep getting refreshed).
+  const targets = new Map<string, boolean>(); // skillsDir -> copy?
+  for (const dir of defaultTargets()) targets.set(path.resolve(dir), copy);
+  for (const dir of extraTo) targets.set(path.resolve(dir), copy);
+  for (const l of recordedLinks()) {
+    const skillsDir = path.dirname(path.resolve(l.path));
+    if (!targets.has(skillsDir)) targets.set(skillsDir, l.mode === "copy");
+  }
+  const links: LinkResult[] = [];
+  for (const [skillsDir, asCopy] of targets) {
+    if (path.resolve(path.join(skillsDir, "surface")) === path.resolve(canonicalDir)) continue;
+    links.push(ensureTarget(skillsDir, canonicalDir, asCopy));
+  }
+  const report: SkillReport = { canonical, version: localVersion(), updated, links };
+  recordSkillState(report);
+  return report;
+}
+
+export function skillFresh(): { canonical: string; fresh: boolean } {
+  const dest = path.join(canonicalSkillDir(), "SKILL.md");
+  try {
+    return { canonical: dest, fresh: fs.readFileSync(dest).equals(fs.readFileSync(packageSkillPath())) };
+  } catch {
+    return { canonical: dest, fresh: false };
+  }
+}
+
+// ── surface skill install ──
+
+export async function runSkill({ positional, flags, multi }: Ctx): Promise<void> {
+  if (positional[0] !== "install") {
+    console.error("usage: surface skill install [--to <skills-dir>]... [--copy] [--json]");
+    process.exit(2);
+  }
+  const report = syncSkill(multi.to || [], flags.copy === true);
+  if (flags.json === true) {
+    console.log(JSON.stringify(report, null, 2));
+    return;
+  }
+  console.log(`skill ${report.version} → ${report.canonical}${report.updated ? " (updated)" : ""}`);
+  for (const l of report.links) {
+    console.log(`  ${l.mode.padEnd(7)} ${l.path}${l.note ? `  (${l.note})` : ""}`);
+  }
+}
+
+// ── surface upgrade ──
+
+function registryUrl(): string {
+  return (process.env.SURFACE_NPM_REGISTRY || "https://registry.npmjs.org").replace(/\/$/, "");
+}
+
+async function latestVersion(): Promise<string> {
+  const url = `${registryUrl()}/surface-display/latest`;
+  let res: Response;
+  try {
+    res = await fetch(url, { signal: AbortSignal.timeout(10_000) });
+  } catch (e: any) {
+    throw new Error(`could not reach the npm registry at ${url} (${e?.cause?.code || e?.code || e?.message || e})`);
+  }
+  if (!res.ok) throw new Error(`registry answered ${res.status} for ${url}`);
+  const body: any = await res.json();
+  if (typeof body?.version !== "string") throw new Error(`no version in registry response from ${url}`);
+  return body.version;
+}
+
+function newerThan(a: string, b: string): boolean {
+  const parse = (v: string) => v.split(/[.+-]/, 3).map((n) => Number(n) || 0);
+  const [a0, a1, a2] = parse(a);
+  const [b0, b1, b2] = parse(b);
+  return a0 !== b0 ? a0 > b0 : a1 !== b1 ? a1 > b1 : a2 > b2;
+}
+
+type InstallContext = "global" | "local" | "dev";
+
+function npmCmd(): string {
+  return process.platform === "win32" ? "npm.cmd" : "npm";
+}
+
+function installContext(): InstallContext {
+  const root = packageRoot();
+  if (path.basename(path.dirname(root)) !== "node_modules") return "dev";
+  const probe = spawnSync(npmCmd(), ["root", "-g"], {
+    encoding: "utf8",
+    shell: process.platform === "win32",
+  });
+  const globalRoot = probe.status === 0 ? probe.stdout.trim() : "";
+  try {
+    if (globalRoot && root.startsWith(fs.realpathSync(globalRoot))) return "global";
+  } catch {
+    // global root missing — treat as local
+  }
+  return "local";
+}
+
+export async function runUpgrade({ flags }: Ctx): Promise<void> {
+  const json = flags.json === true;
+  const timeoutSec = typeof flags.timeout === "string" ? Number(flags.timeout) : 30;
+  const current = localVersion();
+  const latest = await latestVersion();
+  const available = newerThan(latest, current);
+  const context = installContext();
+
+  if (flags.check === true) {
+    const skill = skillFresh();
+    const report = { current, latest, update_available: available, context, skill };
+    if (json) console.log(JSON.stringify(report, null, 2));
+    else {
+      console.log(available ? `update available: ${current} → ${latest}` : `up to date (${current})`);
+      if (!skill.fresh) console.log(`skill copy stale/missing at ${skill.canonical} — run: surface upgrade`);
+      if (available && context !== "global") console.log(contextAdvice(context));
+    }
+    return;
+  }
+
+  let installed = current;
+  let packageStep = "unchanged";
+  if (available && context === "global") {
+    const res = spawnSync(npmCmd(), ["install", "-g", `surface-display@${latest}`], {
+      stdio: "inherit",
+      shell: process.platform === "win32",
+    });
+    if (res.status !== 0) {
+      console.error(`npm install -g surface-display@${latest} failed (exit ${res.status ?? "?"})`);
+      process.exit(1);
+    }
+    // npm replaced the package in place; re-read the version from disk.
+    installed = localVersion();
+    packageStep = `updated ${current} → ${installed}`;
+  } else if (available) {
+    packageStep = `skipped (${context} install)`;
+  }
+
+  // Always converge skill + service, even when already on the latest version —
+  // this is what finishes a manual `npm update -g` someone ran without us.
+  const skill = syncSkill([], false);
+  const service = await restartServiceIfStale(timeoutSec, typeof flags.name === "string" ? flags.name : undefined);
+
+  const report = { previous: current, installed, latest, package: packageStep, context, skill, service };
+  if (json) {
+    console.log(JSON.stringify(report, null, 2));
+    return;
+  }
+  console.log(available && packageStep.startsWith("updated") ? packageStep : `package: ${packageStep === "unchanged" ? `up to date (${current})` : packageStep}`);
+  if (available && context !== "global") console.log(contextAdvice(context));
+  console.log(`skill  : ${skill.version} → ${skill.canonical}${skill.updated ? " (updated)" : ""}`);
+  for (const l of skill.links) console.log(`  ${l.mode.padEnd(7)} ${l.path}${l.note ? `  (${l.note})` : ""}`);
+  if (!service.installed) console.log("service: not installed here — skipped");
+  else if (!service.restarted) console.log(`service: already on ${service.version} — no restart needed`);
+  else if (service.error) {
+    console.error(`service: restarted but not healthy — ${service.error}`);
+    process.exit(1);
+  } else console.log(`service: restarted, now ${service.version}`);
+}
+
+function contextAdvice(context: InstallContext): string {
+  return context === "dev"
+    ? "this is a repo clone — update with: git pull && npm install && npm test"
+    : "surface-display is installed locally here — update with: npm update surface-display (in that project)";
+}

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "test:bindings": "tsx test/bindings.ts",
     "test:content-origin": "tsx test/contentOrigin.ts",
     "test:service": "tsx test/service.ts",
+    "test:upgrade": "tsx test/upgrade.ts",
     "test:e2e": "tsx test/e2e.ts"
   },
   "bin": {

--- a/test/cli.ts
+++ b/test/cli.ts
@@ -27,6 +27,13 @@ assert.equal(help.code, 0);
 assert.match(help.stdout, /--follow/);
 assert.match(help.stdout, /--heartbeat/);
 
+// Service down → a pointer back to the bootstrap flow, not a bare "fetch failed".
+const down = await run(["list"], { SURFACE_URL: "http://127.0.0.1:9" });
+assert.equal(down.code, 1);
+assert.match(down.stderr, /unreachable at http:\/\/127\.0\.0\.1:9/);
+assert.match(down.stderr, /surface service health/);
+assert.match(down.stderr, /INSTALL_FOR_AGENTS\.md/);
+
 const dataDir = tmpDir("surface-cli-data-");
 const scratch = tmpDir("surface-cli-files-");
 const ports = await isolatedPorts();

--- a/test/run-all.ts
+++ b/test/run-all.ts
@@ -10,6 +10,7 @@ const suites = [
   "test:auth",
   "test:content-origin",
   "test:service",
+  "test:upgrade",
   "test:bindings",
   "test:artifacts",
   "test:e2e",

--- a/test/service.ts
+++ b/test/service.ts
@@ -138,6 +138,9 @@ if (!userSystemdAvailable()) {
       assert.equal(health.content_port, CONTENT_PORT);
       assert.equal(health.content_plane_ok, true);
       assert.match(health.version, /^\d+\.\d+\.\d+/);
+      // Upgrade-drift fields ride along in --json (skill copy is absent in this fresh data dir)
+      assert.match(health.cli_version, /^\d+\.\d+\.\d+/);
+      assert.equal(health.skill_copy_state, "missing");
     });
     test("live: status reports registered + running", () => {
       const r = cli(["service", "status", ...common]);

--- a/test/upgrade.ts
+++ b/test/upgrade.ts
@@ -18,9 +18,9 @@ const baseEnv = {
   SURFACE_DATA_DIR: dataDir,
 };
 
-function run(args: string[], env: Record<string, string> = {}): Promise<{ code: number; stdout: string; stderr: string }> {
+function run(args: string[], env: Record<string, string> = {}, bin = cli): Promise<{ code: number; stdout: string; stderr: string }> {
   return new Promise((resolve) => {
-    execFile("node", [cli, ...args], { cwd: REPO_ROOT, env: { ...process.env, ...baseEnv, ...env } }, (error, stdout, stderr) => {
+    execFile("node", [bin, ...args], { cwd: REPO_ROOT, env: { ...process.env, ...baseEnv, ...env } }, (error, stdout, stderr) => {
       resolve({ code: typeof (error as any)?.code === "number" ? (error as any).code : 0, stdout, stderr });
     });
   });
@@ -140,6 +140,21 @@ try {
   const repairedLink = JSON.parse(repaired.stdout).links.find((l: any) => l.path === agentsLink);
   assert.equal(repairedLink.mode, "linked", "misdirected symlink is repointed");
   assert.equal(fs.readFileSync(path.join(agentsLink, "SKILL.md"), "utf8"), pkgSkill);
+
+  // ── but a user's own symlink (unrecorded, non-Surface target) is left alone ──
+  const userSkillDir = path.join(home, "my-skill-fork");
+  fs.mkdirSync(userSkillDir, { recursive: true });
+  fs.writeFileSync(path.join(userSkillDir, "SKILL.md"), "---\nname: my-fork\n---\nthe user's own skill");
+  const userSymDir = path.join(home, ".usersym", "skills");
+  const userSymTarget = path.join(userSymDir, "surface");
+  fs.mkdirSync(userSymDir, { recursive: true });
+  fs.symlinkSync(userSkillDir, userSymTarget, process.platform === "win32" ? "junction" : "dir");
+  const guarded = await run(["skill", "install", "--to", userSymDir, "--json"]);
+  assert.equal(guarded.code, 0, guarded.stderr);
+  const guardedLink = JSON.parse(guarded.stdout).links.find((l: any) => l.path === userSymTarget);
+  assert.equal(guardedLink.mode, "skipped", "an unrecorded symlink to a foreign skill is not repointed");
+  assert.equal(fs.realpathSync(userSymTarget), fs.realpathSync(userSkillDir), "the user's symlink is untouched");
+  assert.equal(fs.readFileSync(path.join(userSymTarget, "SKILL.md"), "utf8"), "---\nname: my-fork\n---\nthe user's own skill");
 
   // ── --copy scope: --to targets only; other recorded targets keep their modes ──
   const copyDir = path.join(home, ".copyharness", "skills");
@@ -346,6 +361,43 @@ try {
     assert.equal(fs.readFileSync(a.canonical, "utf8"), pkgSkill);
   } finally {
     fs.rmSync(path.join(servicesDir, "surface.json"), { force: true });
+  }
+
+  // ── global install path: a fake npm on PATH updates the package, and npm's
+  // chatter never corrupts --json stdout (the bundle is self-contained, so a
+  // copy under node_modules/ behaves exactly like npm install -g put it there) ──
+  const fakePkgRoot = path.join(home, "fake-global", "node_modules", "surface-display");
+  fs.mkdirSync(path.join(fakePkgRoot, "dist"), { recursive: true });
+  fs.copyFileSync(cli, path.join(fakePkgRoot, "dist", "surface.mjs"));
+  fs.copyFileSync(path.join(REPO_ROOT, "package.json"), path.join(fakePkgRoot, "package.json"));
+  fs.copyFileSync(path.join(REPO_ROOT, "SKILL.md"), path.join(fakePkgRoot, "SKILL.md"));
+  const fakeGlobalRoot = path.dirname(fakePkgRoot);
+  const fakeBin = path.join(home, "fake-bin");
+  fs.mkdirSync(fakeBin, { recursive: true });
+  if (process.platform === "win32") {
+    fs.writeFileSync(path.join(fakeBin, "npm.cmd"),
+      `@echo off\r\nif "%1"=="root" (\r\necho ${fakeGlobalRoot}\r\nexit /b 0\r\n)\r\necho added 1 package in 1s\r\nexit /b 0\r\n`);
+  } else {
+    fs.writeFileSync(path.join(fakeBin, "npm"),
+      `#!/bin/sh\nif [ "$1" = "root" ]; then\n  echo "${fakeGlobalRoot}"\n  exit 0\nfi\necho "added 1 package in 1s"\nexit 0\n`,
+      { mode: 0o755 });
+  }
+  const pathKey = Object.keys(process.env).find((k) => k.toUpperCase() === "PATH") || "PATH";
+  const globalEnv = {
+    [pathKey]: `${fakeBin}${path.delimiter}${process.env[pathKey] || ""}`,
+  };
+  const globalReg = await stubRegistry("99.0.0");
+  try {
+    const fakeCli = path.join(fakePkgRoot, "dist", "surface.mjs");
+    const globalUp = await run(["upgrade", "--json", "--name", upgName],
+      { ...globalEnv, SURFACE_NPM_REGISTRY: globalReg.url }, fakeCli);
+    assert.equal(globalUp.code, 0, globalUp.stderr);
+    const g = JSON.parse(globalUp.stdout); // throws if npm output leaked into stdout
+    assert.equal(g.context, "global", "a copy under the npm global root is detected as global");
+    assert.match(g.package, /^updated /, "npm install ran");
+    assert.ok(!globalUp.stdout.includes("added 1 package"), "npm chatter stays out of --json stdout");
+  } finally {
+    globalReg.close();
   }
 
   console.log("Upgrade/skill tests passed");

--- a/test/upgrade.ts
+++ b/test/upgrade.ts
@@ -1,0 +1,178 @@
+import assert from "node:assert/strict";
+import { execFile } from "node:child_process";
+import fs from "node:fs";
+import http from "node:http";
+import path from "node:path";
+import { cleanupDir, REPO_ROOT, tmpDir } from "./helpers.js";
+
+const cli = path.join(REPO_ROOT, "dist", "surface.mjs");
+const pkgSkill = fs.readFileSync(path.join(REPO_ROOT, "SKILL.md"), "utf8");
+const pkgVersion = JSON.parse(fs.readFileSync(path.join(REPO_ROOT, "package.json"), "utf8")).version as string;
+
+const home = tmpDir("surface-upgrade-home-");
+const dataDir = path.join(home, ".surface");
+const baseEnv = {
+  HOME: home,
+  USERPROFILE: home,
+  SURFACE_DATA_DIR: dataDir,
+};
+
+function run(args: string[], env: Record<string, string> = {}): Promise<{ code: number; stdout: string; stderr: string }> {
+  return new Promise((resolve) => {
+    execFile("node", [cli, ...args], { cwd: REPO_ROOT, env: { ...process.env, ...baseEnv, ...env } }, (error, stdout, stderr) => {
+      resolve({ code: typeof (error as any)?.code === "number" ? (error as any).code : 0, stdout, stderr });
+    });
+  });
+}
+
+function stubRegistry(version: string): Promise<{ url: string; close: () => void }> {
+  return new Promise((resolve) => {
+    const server = http.createServer((req, res) => {
+      if (req.url === "/surface-display/latest") {
+        res.setHeader("Content-Type", "application/json");
+        res.end(JSON.stringify({ name: "surface-display", version }));
+      } else {
+        res.statusCode = 404;
+        res.end("{}");
+      }
+    });
+    server.listen(0, "127.0.0.1", () => {
+      const addr = server.address() as { port: number };
+      resolve({ url: `http://127.0.0.1:${addr.port}`, close: () => server.close() });
+    });
+  });
+}
+
+const canonical = path.join(dataDir, "skills", "surface", "SKILL.md");
+const agentsLink = path.join(home, ".agents", "skills", "surface");
+const claudeLink = path.join(home, ".claude", "skills", "surface");
+
+try {
+  // ── skill install: canonical copy + default links ──
+  const install = await run(["skill", "install", "--json"]);
+  assert.equal(install.code, 0, install.stderr);
+  const report = JSON.parse(install.stdout);
+  assert.equal(report.canonical, canonical);
+  assert.equal(fs.readFileSync(canonical, "utf8"), pkgSkill, "canonical copy matches the package SKILL.md");
+  for (const link of [agentsLink, claudeLink]) {
+    assert.ok(fs.lstatSync(link).isSymbolicLink(), `${link} is a symlink`);
+    assert.equal(fs.readFileSync(path.join(link, "SKILL.md"), "utf8"), pkgSkill, `${link} resolves to the skill`);
+  }
+
+  // install-state.json records the canonical path and the links
+  const state = JSON.parse(fs.readFileSync(path.join(dataDir, "install-state.json"), "utf8"));
+  assert.equal(state.skill_saved_to, canonical);
+  assert.equal(state.skill_links.length, 2);
+  assert.equal(state.tutorial, "pending", "fresh state file keeps the documented defaults");
+
+  // ── idempotent: second run keeps links, changes nothing ──
+  const again = await run(["skill", "install", "--json"]);
+  const report2 = JSON.parse(again.stdout);
+  assert.equal(report2.updated, false);
+  assert.ok(report2.links.every((l: any) => l.mode === "kept"), "second run keeps existing links");
+
+  // ── --to adds a harness dir; recorded for future refreshes ──
+  const clineDir = path.join(home, ".cline", "skills");
+  const withTo = await run(["skill", "install", "--to", clineDir, "--json"]);
+  assert.equal(withTo.code, 0, withTo.stderr);
+  assert.equal(fs.readFileSync(path.join(clineDir, "surface", "SKILL.md"), "utf8"), pkgSkill);
+  const state2 = JSON.parse(fs.readFileSync(path.join(dataDir, "install-state.json"), "utf8"));
+  assert.equal(state2.skill_links.length, 3);
+
+  // ── a foreign skill dir is never clobbered ──
+  const foreign = path.join(home, ".foreign", "skills");
+  fs.mkdirSync(path.join(foreign, "surface"), { recursive: true });
+  fs.writeFileSync(path.join(foreign, "surface", "SKILL.md"), "someone else's skill");
+  fs.writeFileSync(path.join(foreign, "surface", "notes.txt"), "keep me");
+  const refused = await run(["skill", "install", "--to", foreign, "--json"]);
+  const refusedReport = JSON.parse(refused.stdout);
+  const skipped = refusedReport.links.find((l: any) => l.path === path.join(foreign, "surface"));
+  assert.equal(skipped.mode, "skipped");
+  assert.equal(fs.readFileSync(path.join(foreign, "surface", "notes.txt"), "utf8"), "keep me");
+
+  // ── but a stale plain copy (only SKILL.md inside) is upgraded to a link ──
+  const legacy = path.join(home, ".legacy", "skills");
+  fs.mkdirSync(path.join(legacy, "surface"), { recursive: true });
+  fs.writeFileSync(path.join(legacy, "surface", "SKILL.md"), "old copy");
+  const upgraded = await run(["skill", "install", "--to", legacy, "--json"]);
+  const upgradedReport = JSON.parse(upgraded.stdout);
+  const relinked = upgradedReport.links.find((l: any) => l.path === path.join(legacy, "surface"));
+  assert.equal(relinked.mode, "linked");
+  assert.equal(fs.readFileSync(path.join(legacy, "surface", "SKILL.md"), "utf8"), pkgSkill);
+
+  // ── --copy forces managed copies instead of links (all targets in the run) ──
+  const copyDir = path.join(home, ".copyharness", "skills");
+  const copied = await run(["skill", "install", "--to", copyDir, "--copy", "--json"]);
+  assert.equal(copied.code, 0, copied.stderr);
+  const copiedTarget = path.join(copyDir, "surface");
+  assert.ok(!fs.lstatSync(copiedTarget).isSymbolicLink(), "copy mode creates a real directory");
+  assert.equal(fs.readFileSync(path.join(copiedTarget, "SKILL.md"), "utf8"), pkgSkill);
+  assert.ok(!fs.lstatSync(agentsLink).isSymbolicLink(), "--copy converges default targets to copies too");
+  const state3 = JSON.parse(fs.readFileSync(path.join(dataDir, "install-state.json"), "utf8"));
+  assert.ok(state3.skill_links.some((l: any) => l.path === copiedTarget && l.mode === "copy"), "copy recorded as copy");
+
+  // ── and a plain run converges defaults back to links (copies hold their recorded mode) ──
+  const relink = await run(["skill", "install", "--json"]);
+  assert.equal(relink.code, 0, relink.stderr);
+  assert.ok(fs.lstatSync(agentsLink).isSymbolicLink(), "plain install converges defaults back to links");
+  assert.ok(!fs.lstatSync(copiedTarget).isSymbolicLink(), "recorded copy target stays a copy");
+
+  // ── a wrong symlink is repaired ──
+  fs.unlinkSync(agentsLink);
+  fs.symlinkSync(path.join(home, ".foreign"), agentsLink, "dir");
+  const repaired = await run(["skill", "install", "--json"]);
+  const repairedLink = JSON.parse(repaired.stdout).links.find((l: any) => l.path === agentsLink);
+  assert.equal(repairedLink.mode, "linked", "misdirected symlink is repointed");
+  assert.equal(fs.readFileSync(path.join(agentsLink, "SKILL.md"), "utf8"), pkgSkill);
+
+  // ── upgrade --check against a stub registry ──
+  const same = await stubRegistry(pkgVersion);
+  try {
+    const check = await run(["upgrade", "--check", "--json"], { SURFACE_NPM_REGISTRY: same.url });
+    assert.equal(check.code, 0, check.stderr);
+    const c = JSON.parse(check.stdout);
+    assert.equal(c.update_available, false);
+    assert.equal(c.context, "dev", "repo clone is detected as a dev install");
+    assert.equal(c.skill.fresh, true);
+  } finally {
+    same.close();
+  }
+
+  // ── upgrade with a newer release: dev context skips npm but still converges ──
+  fs.writeFileSync(canonical, "stale skill text"); // sabotage the canonical copy
+  fs.writeFileSync(path.join(copiedTarget, "SKILL.md"), "stale copy"); // and a recorded copy
+  const newer = await stubRegistry("99.0.0");
+  try {
+    const check2 = await run(["upgrade", "--check", "--json"], { SURFACE_NPM_REGISTRY: newer.url });
+    const c2 = JSON.parse(check2.stdout);
+    assert.equal(c2.update_available, true);
+    assert.equal(c2.skill.fresh, false, "--check flags the sabotaged canonical copy");
+    assert.equal(fs.readFileSync(canonical, "utf8"), "stale skill text", "--check changes nothing");
+
+    // --name keeps the test away from any real "surface" service on this machine
+    const up = await run(["upgrade", "--json", "--name", `surface-upg-test-${process.pid}`], { SURFACE_NPM_REGISTRY: newer.url });
+    assert.equal(up.code, 0, up.stderr);
+    const u = JSON.parse(up.stdout);
+    assert.equal(u.package, "skipped (dev install)");
+    assert.equal(u.skill.updated, true, "stale canonical copy was refreshed");
+    assert.equal(fs.readFileSync(canonical, "utf8"), pkgSkill);
+    assert.equal(fs.readFileSync(path.join(copiedTarget, "SKILL.md"), "utf8"), pkgSkill, "recorded copies are refreshed by upgrade");
+    assert.equal(u.service.installed, false, "no service registered in the sandbox");
+  } finally {
+    newer.close();
+  }
+
+  // ── registry unreachable → clear failure ──
+  const dead = await run(["upgrade", "--check"], { SURFACE_NPM_REGISTRY: "http://127.0.0.1:9" });
+  assert.equal(dead.code, 1);
+  assert.match(dead.stderr, /could not reach the npm registry/);
+
+  // ── surface service update/upgrade redirects to the real command ──
+  const redirect = await run(["service", "upgrade"]);
+  assert.equal(redirect.code, 2);
+  assert.match(redirect.stderr, /did you mean: surface upgrade/);
+
+  console.log("Upgrade/skill tests passed");
+} finally {
+  cleanupDir(home);
+}

--- a/test/upgrade.ts
+++ b/test/upgrade.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { execFile } from "node:child_process";
+import { execFile, spawnSync } from "node:child_process";
 import fs from "node:fs";
 import http from "node:http";
 import path from "node:path";
@@ -43,6 +43,14 @@ function stubRegistry(version: string): Promise<{ url: string; close: () => void
   });
 }
 
+function readState(): any {
+  return JSON.parse(fs.readFileSync(path.join(dataDir, "install-state.json"), "utf8"));
+}
+
+function isLink(p: string): boolean {
+  return fs.lstatSync(p).isSymbolicLink();
+}
+
 const canonical = path.join(dataDir, "skills", "surface", "SKILL.md");
 const agentsLink = path.join(home, ".agents", "skills", "surface");
 const claudeLink = path.join(home, ".claude", "skills", "surface");
@@ -55,12 +63,12 @@ try {
   assert.equal(report.canonical, canonical);
   assert.equal(fs.readFileSync(canonical, "utf8"), pkgSkill, "canonical copy matches the package SKILL.md");
   for (const link of [agentsLink, claudeLink]) {
-    assert.ok(fs.lstatSync(link).isSymbolicLink(), `${link} is a symlink`);
+    assert.ok(isLink(link), `${link} is a symlink`);
     assert.equal(fs.readFileSync(path.join(link, "SKILL.md"), "utf8"), pkgSkill, `${link} resolves to the skill`);
   }
 
   // install-state.json records the canonical path and the links
-  const state = JSON.parse(fs.readFileSync(path.join(dataDir, "install-state.json"), "utf8"));
+  const state = readState();
   assert.equal(state.skill_saved_to, canonical);
   assert.equal(state.skill_links.length, 2);
   assert.equal(state.tutorial, "pending", "fresh state file keeps the documented defaults");
@@ -73,13 +81,13 @@ try {
 
   // ── --to adds a harness dir; recorded for future refreshes ──
   const clineDir = path.join(home, ".cline", "skills");
+  const clineTarget = path.join(clineDir, "surface");
   const withTo = await run(["skill", "install", "--to", clineDir, "--json"]);
   assert.equal(withTo.code, 0, withTo.stderr);
-  assert.equal(fs.readFileSync(path.join(clineDir, "surface", "SKILL.md"), "utf8"), pkgSkill);
-  const state2 = JSON.parse(fs.readFileSync(path.join(dataDir, "install-state.json"), "utf8"));
-  assert.equal(state2.skill_links.length, 3);
+  assert.equal(fs.readFileSync(path.join(clineTarget, "SKILL.md"), "utf8"), pkgSkill);
+  assert.equal(readState().skill_links.length, 3);
 
-  // ── a foreign skill dir is never clobbered ──
+  // ── a foreign skill dir (extra files) is never clobbered ──
   const foreign = path.join(home, ".foreign", "skills");
   fs.mkdirSync(path.join(foreign, "surface"), { recursive: true });
   fs.writeFileSync(path.join(foreign, "surface", "SKILL.md"), "someone else's skill");
@@ -90,32 +98,23 @@ try {
   assert.equal(skipped.mode, "skipped");
   assert.equal(fs.readFileSync(path.join(foreign, "surface", "notes.txt"), "utf8"), "keep me");
 
-  // ── but a stale plain copy (only SKILL.md inside) is upgraded to a link ──
+  // ── a lone SKILL.md that is NOT a Surface skill is skipped too ──
+  const stranger = path.join(home, ".stranger", "skills");
+  fs.mkdirSync(path.join(stranger, "surface"), { recursive: true });
+  fs.writeFileSync(path.join(stranger, "surface", "SKILL.md"), "---\nname: not-ours\n---\ncustom skill");
+  const strangerRun = await run(["skill", "install", "--to", stranger, "--json"]);
+  const strangerLink = JSON.parse(strangerRun.stdout).links.find((l: any) => l.path === path.join(stranger, "surface"));
+  assert.equal(strangerLink.mode, "skipped", "lone non-Surface SKILL.md is not adopted");
+  assert.equal(fs.readFileSync(path.join(stranger, "surface", "SKILL.md"), "utf8"), "---\nname: not-ours\n---\ncustom skill");
+
+  // ── but a stale Surface copy (lone SKILL.md, name: surface) upgrades to a link ──
   const legacy = path.join(home, ".legacy", "skills");
   fs.mkdirSync(path.join(legacy, "surface"), { recursive: true });
-  fs.writeFileSync(path.join(legacy, "surface", "SKILL.md"), "old copy");
+  fs.writeFileSync(path.join(legacy, "surface", "SKILL.md"), "---\nname: surface\ndescription: old\n---\nold copy");
   const upgraded = await run(["skill", "install", "--to", legacy, "--json"]);
-  const upgradedReport = JSON.parse(upgraded.stdout);
-  const relinked = upgradedReport.links.find((l: any) => l.path === path.join(legacy, "surface"));
+  const relinked = JSON.parse(upgraded.stdout).links.find((l: any) => l.path === path.join(legacy, "surface"));
   assert.equal(relinked.mode, "linked");
   assert.equal(fs.readFileSync(path.join(legacy, "surface", "SKILL.md"), "utf8"), pkgSkill);
-
-  // ── --copy forces managed copies instead of links (all targets in the run) ──
-  const copyDir = path.join(home, ".copyharness", "skills");
-  const copied = await run(["skill", "install", "--to", copyDir, "--copy", "--json"]);
-  assert.equal(copied.code, 0, copied.stderr);
-  const copiedTarget = path.join(copyDir, "surface");
-  assert.ok(!fs.lstatSync(copiedTarget).isSymbolicLink(), "copy mode creates a real directory");
-  assert.equal(fs.readFileSync(path.join(copiedTarget, "SKILL.md"), "utf8"), pkgSkill);
-  assert.ok(!fs.lstatSync(agentsLink).isSymbolicLink(), "--copy converges default targets to copies too");
-  const state3 = JSON.parse(fs.readFileSync(path.join(dataDir, "install-state.json"), "utf8"));
-  assert.ok(state3.skill_links.some((l: any) => l.path === copiedTarget && l.mode === "copy"), "copy recorded as copy");
-
-  // ── and a plain run converges defaults back to links (copies hold their recorded mode) ──
-  const relink = await run(["skill", "install", "--json"]);
-  assert.equal(relink.code, 0, relink.stderr);
-  assert.ok(fs.lstatSync(agentsLink).isSymbolicLink(), "plain install converges defaults back to links");
-  assert.ok(!fs.lstatSync(copiedTarget).isSymbolicLink(), "recorded copy target stays a copy");
 
   // ── a wrong symlink is repaired ──
   fs.unlinkSync(agentsLink);
@@ -125,6 +124,42 @@ try {
   const repairedLink = JSON.parse(repaired.stdout).links.find((l: any) => l.path === agentsLink);
   assert.equal(repairedLink.mode, "linked", "misdirected symlink is repointed");
   assert.equal(fs.readFileSync(path.join(agentsLink, "SKILL.md"), "utf8"), pkgSkill);
+
+  // ── --copy scope: --to targets only; other recorded targets keep their modes ──
+  const copyDir = path.join(home, ".copyharness", "skills");
+  const copiedTarget = path.join(copyDir, "surface");
+  const copied = await run(["skill", "install", "--to", copyDir, "--copy", "--json"]);
+  assert.equal(copied.code, 0, copied.stderr);
+  assert.ok(!isLink(copiedTarget), "--copy creates a real directory for the --to target");
+  assert.equal(fs.readFileSync(path.join(copiedTarget, "SKILL.md"), "utf8"), pkgSkill);
+  assert.ok(isLink(agentsLink), "defaults are out of scope when --to is given — still links");
+  assert.ok(isLink(clineTarget), "other recorded targets keep their modes");
+  assert.ok(readState().skill_links.some((l: any) => l.path === copiedTarget && l.mode === "copy"), "copy recorded as copy");
+
+  // ── --copy without --to: defaults become copies; recorded extras stay put (mixed modes) ──
+  const copyDefaults = await run(["skill", "install", "--copy", "--json"]);
+  assert.equal(copyDefaults.code, 0, copyDefaults.stderr);
+  assert.ok(!isLink(agentsLink), "--copy converts the default targets");
+  assert.ok(!isLink(claudeLink), "--copy converts the default targets");
+  assert.ok(isLink(clineTarget), "recorded link outside the scope stays a link");
+  assert.ok(!isLink(copiedTarget), "recorded copy stays a copy");
+
+  // ── modes are sticky: a plain run reshapes nothing ──
+  const plain = await run(["skill", "install", "--json"]);
+  assert.equal(plain.code, 0, plain.stderr);
+  assert.ok(!isLink(agentsLink), "plain run keeps the recorded copy mode");
+  assert.ok(isLink(clineTarget), "plain run keeps the recorded link mode");
+
+  // ── --link converts the scope back; out-of-scope copies survive ──
+  const relink = await run(["skill", "install", "--link", "--json"]);
+  assert.equal(relink.code, 0, relink.stderr);
+  assert.ok(isLink(agentsLink), "--link converts the defaults back to links");
+  assert.ok(isLink(claudeLink), "--link converts the defaults back to links");
+  assert.ok(!isLink(copiedTarget), "recorded copy outside the scope stays a copy");
+
+  // ── --copy and --link together is an error ──
+  const both = await run(["skill", "install", "--copy", "--link"]);
+  assert.equal(both.code, 2);
 
   // ── upgrade --check against a stub registry ──
   const same = await stubRegistry(pkgVersion);
@@ -140,6 +175,7 @@ try {
   }
 
   // ── upgrade with a newer release: dev context skips npm but still converges ──
+  const upgName = `surface-upg-test-${process.pid}`;
   fs.writeFileSync(canonical, "stale skill text"); // sabotage the canonical copy
   fs.writeFileSync(path.join(copiedTarget, "SKILL.md"), "stale copy"); // and a recorded copy
   const newer = await stubRegistry("99.0.0");
@@ -151,7 +187,7 @@ try {
     assert.equal(fs.readFileSync(canonical, "utf8"), "stale skill text", "--check changes nothing");
 
     // --name keeps the test away from any real "surface" service on this machine
-    const up = await run(["upgrade", "--json", "--name", `surface-upg-test-${process.pid}`], { SURFACE_NPM_REGISTRY: newer.url });
+    const up = await run(["upgrade", "--json", "--name", upgName], { SURFACE_NPM_REGISTRY: newer.url });
     assert.equal(up.code, 0, up.stderr);
     const u = JSON.parse(up.stdout);
     assert.equal(u.package, "skipped (dev install)");
@@ -163,6 +199,50 @@ try {
     newer.close();
   }
 
+  // ── one unwritable target doesn't abort the converger ──
+  const canChmod = process.platform !== "win32" && !(typeof process.getuid === "function" && process.getuid() === 0);
+  if (canChmod) {
+    const lockedFile = path.join(copiedTarget, "SKILL.md");
+    fs.chmodSync(lockedFile, 0o444);
+    fs.writeFileSync(canonical, "stale again");
+    const reg = await stubRegistry(pkgVersion);
+    try {
+      const partial = await run(["upgrade", "--json", "--name", upgName], { SURFACE_NPM_REGISTRY: reg.url });
+      assert.equal(partial.code, 1, "a failed target makes upgrade exit 1");
+      const p = JSON.parse(partial.stdout);
+      const failed = p.skill.links.find((l: any) => l.path === copiedTarget);
+      assert.equal(failed.mode, "failed", "the unwritable target is reported, not thrown");
+      assert.equal(fs.readFileSync(canonical, "utf8"), pkgSkill, "canonical still converged");
+      assert.ok(p.service, "the service step still ran");
+      assert.ok(readState().skill_links.some((l: any) => l.path === copiedTarget && l.mode === "copy"),
+        "a failed target stays recorded for the next retry");
+
+      fs.chmodSync(lockedFile, 0o644);
+      const retry = await run(["upgrade", "--json", "--name", upgName], { SURFACE_NPM_REGISTRY: reg.url });
+      assert.equal(retry.code, 0, retry.stderr);
+      assert.equal(fs.readFileSync(lockedFile, "utf8"), pkgSkill, "the retried target converges");
+    } finally {
+      reg.close();
+      try {
+        fs.chmodSync(lockedFile, 0o644);
+      } catch {
+        // already restored
+      }
+    }
+  } else {
+    console.log("  SKIP  unwritable-target isolation (chmod ineffective here)");
+  }
+
+  // ── a garbage registry version never reaches npm ──
+  const evil = await stubRegistry('99.0.0"; calc.exe; "');
+  try {
+    const inj = await run(["upgrade", "--check"], { SURFACE_NPM_REGISTRY: evil.url });
+    assert.equal(inj.code, 1);
+    assert.match(inj.stderr, /invalid version/);
+  } finally {
+    evil.close();
+  }
+
   // ── registry unreachable → clear failure ──
   const dead = await run(["upgrade", "--check"], { SURFACE_NPM_REGISTRY: "http://127.0.0.1:9" });
   assert.equal(dead.code, 1);
@@ -172,6 +252,44 @@ try {
   const redirect = await run(["service", "upgrade"]);
   assert.equal(redirect.code, 2);
   assert.match(redirect.stderr, /did you mean: surface upgrade/);
+
+  // ── a registered but cleanly stopped service is left stopped ──
+  const systemd = process.platform === "linux" && spawnSync("systemctl", ["--user", "show-environment"], { encoding: "utf8" }).status === 0;
+  if (systemd) {
+    const stopName = `surface-upg-stop-${process.pid}`;
+    const unitDir = path.join(home, ".config", "systemd", "user");
+    fs.mkdirSync(unitDir, { recursive: true });
+    fs.writeFileSync(path.join(unitDir, `${stopName}.service`), "[Unit]\nDescription=surface upgrade test stub\n[Service]\nExecStart=/bin/true\n");
+    const reg = await stubRegistry(pkgVersion);
+    try {
+      const stopped = await run(["upgrade", "--json", "--name", stopName], { SURFACE_NPM_REGISTRY: reg.url });
+      assert.equal(stopped.code, 0, stopped.stderr);
+      const s = JSON.parse(stopped.stdout);
+      assert.equal(s.service.installed, true, "unit file counts as registered");
+      assert.equal(s.service.restarted, false, "a stopped service is never started by upgrade");
+      assert.equal(s.service.state, "inactive");
+    } finally {
+      reg.close();
+    }
+  } else {
+    console.log("  SKIP  stopped-service guard (no user systemd session)");
+  }
+
+  // ── the skill anchors in the service's saved data dir, matching service health ──
+  const altData = path.join(home, "alt-surface-data");
+  const servicesDir = path.join(home, ".surface", "services");
+  fs.mkdirSync(servicesDir, { recursive: true });
+  fs.writeFileSync(path.join(servicesDir, "surface.json"), JSON.stringify({ dataDir: altData }) + "\n");
+  try {
+    const anchored = await run(["skill", "install", "--json"]);
+    assert.equal(anchored.code, 0, anchored.stderr);
+    const a = JSON.parse(anchored.stdout);
+    assert.equal(a.canonical, path.join(altData, "skills", "surface", "SKILL.md"),
+      "saved service data dir beats SURFACE_DATA_DIR, like resolveConfig");
+    assert.equal(fs.readFileSync(a.canonical, "utf8"), pkgSkill);
+  } finally {
+    fs.rmSync(path.join(servicesDir, "surface.json"), { force: true });
+  }
 
   console.log("Upgrade/skill tests passed");
 } finally {

--- a/test/upgrade.ts
+++ b/test/upgrade.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import { execFile, spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
 import fs from "node:fs";
 import http from "node:http";
 import path from "node:path";
@@ -47,6 +48,20 @@ function readState(): any {
   return JSON.parse(fs.readFileSync(path.join(dataDir, "install-state.json"), "utf8"));
 }
 
+function sha256(s: string): string {
+  return createHash("sha256").update(s).digest("hex");
+}
+
+// Simulate a stale copy WE wrote (an older release's text): write the content
+// and stamp its hash as skill_sha256, exactly like a previous version did.
+function plantStaleCanonical(content: string): void {
+  fs.writeFileSync(canonical, content);
+  const p = path.join(dataDir, "install-state.json");
+  const s = JSON.parse(fs.readFileSync(p, "utf8"));
+  s.skill_sha256 = sha256(content);
+  fs.writeFileSync(p, JSON.stringify(s, null, 2) + "\n");
+}
+
 function isLink(p: string): boolean {
   return fs.lstatSync(p).isSymbolicLink();
 }
@@ -71,6 +86,7 @@ try {
   const state = readState();
   assert.equal(state.skill_saved_to, canonical);
   assert.equal(state.skill_links.length, 2);
+  assert.equal(state.skill_sha256, sha256(pkgSkill), "the hash of what we wrote is stamped");
   assert.equal(state.tutorial, "pending", "fresh state file keeps the documented defaults");
 
   // ── idempotent: second run keeps links, changes nothing ──
@@ -176,8 +192,8 @@ try {
 
   // ── upgrade with a newer release: dev context skips npm but still converges ──
   const upgName = `surface-upg-test-${process.pid}`;
-  fs.writeFileSync(canonical, "stale skill text"); // sabotage the canonical copy
-  fs.writeFileSync(path.join(copiedTarget, "SKILL.md"), "stale copy"); // and a recorded copy
+  plantStaleCanonical("stale skill text"); // an older release's canonical copy
+  fs.writeFileSync(path.join(copiedTarget, "SKILL.md"), "stale copy"); // and a stale recorded copy
   const newer = await stubRegistry("99.0.0");
   try {
     const check2 = await run(["upgrade", "--check", "--json"], { SURFACE_NPM_REGISTRY: newer.url });
@@ -204,7 +220,7 @@ try {
   if (canChmod) {
     const lockedFile = path.join(copiedTarget, "SKILL.md");
     fs.chmodSync(lockedFile, 0o444);
-    fs.writeFileSync(canonical, "stale again");
+    plantStaleCanonical("stale again");
     const reg = await stubRegistry(pkgVersion);
     try {
       const partial = await run(["upgrade", "--json", "--name", upgName], { SURFACE_NPM_REGISTRY: reg.url });
@@ -252,6 +268,47 @@ try {
   const redirect = await run(["service", "upgrade"]);
   assert.equal(redirect.code, 2);
   assert.match(redirect.stderr, /did you mean: surface upgrade/);
+
+  // ── a user-edited canonical is kept, mirrored to targets, and only --force replaces it ──
+  const editedSkill = pkgSkill + "\n<!-- my local tweak -->\n";
+  fs.writeFileSync(canonical, editedSkill); // hash no longer matches skill_sha256
+  const keep = await run(["skill", "install", "--json"]);
+  assert.equal(keep.code, 0, keep.stderr);
+  const keptReport = JSON.parse(keep.stdout);
+  assert.equal(keptReport.edited, true, "an edited canonical is reported");
+  assert.equal(fs.readFileSync(canonical, "utf8"), editedSkill, "the edit is kept");
+  assert.equal(fs.readFileSync(path.join(copiedTarget, "SKILL.md"), "utf8"), editedSkill,
+    "managed copies mirror the canonical, edits included");
+  assert.equal(readState().skill_sha256, sha256(pkgSkill),
+    "the recorded hash still names OUR content — the edit is never adopted as ours");
+
+  const editedCheck = await stubRegistry(pkgVersion);
+  try {
+    const ec = await run(["upgrade", "--check", "--json"], { SURFACE_NPM_REGISTRY: editedCheck.url });
+    const e = JSON.parse(ec.stdout);
+    assert.equal(e.skill.fresh, false);
+    assert.equal(e.skill.edited, true, "--check tells edited apart from stale");
+
+    // upgrade keeps the edit too — it converges versions, not opinions
+    const upKeep = await run(["upgrade", "--json", "--name", upgName], { SURFACE_NPM_REGISTRY: editedCheck.url });
+    assert.equal(upKeep.code, 0, upKeep.stderr);
+    assert.equal(JSON.parse(upKeep.stdout).skill.edited, true);
+    assert.equal(fs.readFileSync(canonical, "utf8"), editedSkill, "upgrade never clobbers an edit");
+  } finally {
+    editedCheck.close();
+  }
+
+  // service health reports the edited state (dead port: only the skill fields matter)
+  const health = await run(["service", "health", "--json", "--port", "9"]);
+  assert.equal(JSON.parse(health.stdout).skill_copy_state, "edited");
+
+  const forced = await run(["skill", "install", "--force", "--json"]);
+  assert.equal(forced.code, 0, forced.stderr);
+  const forcedReport = JSON.parse(forced.stdout);
+  assert.equal(forcedReport.edited, false);
+  assert.equal(forcedReport.updated, true, "--force replaces the edit with the packaged skill");
+  assert.equal(fs.readFileSync(canonical, "utf8"), pkgSkill);
+  assert.equal(fs.readFileSync(path.join(copiedTarget, "SKILL.md"), "utf8"), pkgSkill, "copies re-mirror the package");
 
   // ── a registered but cleanly stopped service is left stopped ──
   const systemd = process.platform === "linux" && spawnSync("systemctl", ["--user", "show-environment"], { encoding: "utf8" }).status === 0;

--- a/test/upgrade.ts
+++ b/test/upgrade.ts
@@ -119,7 +119,8 @@ try {
 
   // ── a wrong symlink is repaired ──
   fs.unlinkSync(agentsLink);
-  fs.symlinkSync(path.join(home, ".foreign"), agentsLink, "dir");
+  // junction on win32: dir symlinks can need elevation there (matches production linking)
+  fs.symlinkSync(path.join(home, ".foreign"), agentsLink, process.platform === "win32" ? "junction" : "dir");
   const repaired = await run(["skill", "install", "--json"]);
   const repairedLink = JSON.parse(repaired.stdout).links.find((l: any) => l.path === agentsLink);
   assert.equal(repairedLink.mode, "linked", "misdirected symlink is repointed");


### PR DESCRIPTION
## What

Two commands that close the skill-distribution and upgrade loop; no other surface area changes.

### `surface upgrade` — the one-command converger

- Updates `surface-display` to the **latest npm release** (checks the registry; `SURFACE_NPM_REGISTRY` overridable, which is also how tests stay hermetic).
- Detects its install context: **global npm** → runs `npm install -g surface-display@<latest>`; **repo clone / project-local** → skips npm and prints the right advice instead of guessing.
- Refreshes the canonical `SKILL.md` copy and **every recorded skill link/copy** — also when the package was already current, so it finishes a manual `npm update -g` someone ran without it.
- Restarts the service **only when** it is registered and reports an older version than the CLI (health-gated; `--name` for non-default service names).
- `--check` is read-only; `--json` throughout. `surface service update`/`upgrade` redirect here.

### `surface skill install` — one canonical copy, linked everywhere

- Canonical `SKILL.md` at `<data-dir>/skills/surface/`, directory-linked (junction on Windows; managed copy where symlinks are forbidden — recorded and refreshed on upgrade) into:
  - `~/.agents/skills/` — the agentskills.io open standard (Codex, Cursor, Gemini CLI, Copilot, Zed, Amp, Goose, OpenCode, Roo, Kilo, Windsurf)
  - `~/.claude/skills/` — Claude Code (reads only its own dir)
- `--to` adds harness-native dirs (e.g. `~/.cline/skills`); `--copy` forces copies for every target in the run.
- Refuses to touch a skill directory containing files it does not own; stamps `skill_saved_to`/`skill_links` in `install-state.json`; idempotent converger (plain runs converge to links, `--copy` runs to copies, recorded modes preserved by `upgrade`).

### Why this design

The skill text agents read must version-lock to the installed binary. `npx skills add` tracks git master (master may hold unreleased work — see STATUS.md distribution rules); linking into `$(npm root -g)` dangles when nvm switches node. The data-dir canonical path survives both; `surface upgrade` keeps it current. Decision recorded in STATUS.md.

### Tied into existing paths

- `surface service health`: skill-copy drift now reported — structured `cli_version`/`skill_copy_state` in `--json`, human notes otherwise; version-drift note now points at `surface upgrade`.
- CLI now prints "Surface service unreachable at <url> — is it running? …" with the install one-liner instead of a bare `fetch failed`.
- INSTALL_FOR_AGENTS.md Step 2 + Upgrading collapse to the two commands; the vendor-doc-verified per-harness directory list (2026-07) stays as `--to` reference.

## Tests

New `test:upgrade` suite (wired into run-all + CI): canonical copy + default links, symlink-through reads, idempotence, `--to` recording, foreign-skill-dir refusal, legacy-copy→link upgrade, misdirected-symlink repair (**caught a real EISDIR bug** in the replace path — symlinks must be unlinked, not rm'd), copy/link convergence, `--check` against a stub registry (same + newer version), dev-context npm skip with canonical+copy refresh, unreachable-registry failure, `service upgrade` redirect. `test/cli.ts` covers the service-down hint; `test/service.ts` asserts the new health JSON fields. The upgrade test uses a unique `--name` so it can never restart a real service.

Full gate green: `npx tsc --noEmit`, `npm test` (12/12 suites), `npm audit --audit-level=high`, `scripts/check-leaks.sh`.